### PR TITLE
Migrate multiexp package to clang

### DIFF
--- a/sxt/execution/device/synchronization.h
+++ b/sxt/execution/device/synchronization.h
@@ -80,7 +80,7 @@ xena::future<std::remove_cvref_t<T>> await_and_own_stream(basdv::stream&& stream
 // synchronize_event
 //--------------------------------------------------------------------------------------------------
 template <class T>
-void synchronize_event(bast::raw_stream_t stream, const event_future<T>& future) noexcept {
+void synchronize_event(bast::raw_stream_t stream, event_future<T>& future) noexcept {
   auto& event_maybe = future.event();
   if (!event_maybe) {
     return;

--- a/sxt/multiexp/base/BUILD
+++ b/sxt/multiexp/base/BUILD
@@ -1,0 +1,44 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "generator_utility",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:blob_array",
+        "//sxt/base/container:span",
+        "//sxt/base/error:assert",
+    ],
+)
+
+sxt_cc_component(
+    name = "digit_utility",
+    impl_deps = [
+        "//sxt/base/bit:count",
+        "//sxt/base/num:divide_up",
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "exponent_sequence",
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "exponent_sequence_utility",
+    with_test = False,
+    deps = [
+        ":exponent_sequence",
+    ],
+)

--- a/sxt/multiexp/base/digit_utility.cc
+++ b/sxt/multiexp/base/digit_utility.cc
@@ -1,0 +1,102 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/digit_utility.h"
+
+#include "sxt/base/bit/count.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/num/divide_up.h"
+
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// extract_digit
+//--------------------------------------------------------------------------------------------------
+void extract_digit(basct::span<uint8_t> digit, basct::cspan<uint8_t> e, size_t radix_log2,
+                   size_t digit_index) noexcept {
+  SXT_DEBUG_ASSERT(digit.size() == basn::divide_up(radix_log2, 8ul));
+  auto digit_num_bytes = digit.size();
+  auto bit_first = radix_log2 * digit_index;
+  SXT_DEBUG_ASSERT(e.size() * 8 > bit_first);
+  auto byte_first = bit_first / 8;
+  auto offset = bit_first - 8 * byte_first;
+  digit[0] = e[byte_first] >> offset;
+  auto byte_last = std::min(digit_num_bytes, e.size() - byte_first);
+  for (size_t byte_index = 1; byte_index < byte_last; ++byte_index) {
+    auto byte = e[byte_first + byte_index];
+    digit[byte_index - 1] |= byte << (8 - offset);
+    digit[byte_index] = byte >> offset;
+  }
+  for (size_t byte_index = byte_last; byte_index < digit_num_bytes; ++byte_index) {
+    digit[byte_index] = 0;
+  }
+  if (offset + radix_log2 > 8 && byte_first + digit_num_bytes < e.size()) {
+    digit[digit_num_bytes - 1] |= e[byte_first + digit_num_bytes] << (8 - offset);
+  }
+  constexpr uint8_t ones = 0xff;
+  digit[digit_num_bytes - 1] &= ones >> (digit_num_bytes * 8 - radix_log2);
+}
+
+//--------------------------------------------------------------------------------------------------
+// is_digit_zero
+//--------------------------------------------------------------------------------------------------
+bool is_digit_zero(basct::cspan<uint8_t> e, size_t radix_log2, size_t digit_index) noexcept {
+  auto bit_first = radix_log2 * digit_index;
+  auto i = bit_first / 8;
+  auto offset = bit_first - 8 * i;
+  uint8_t b = e[i] & (static_cast<uint8_t>(-1) << offset);
+  size_t count = radix_log2 + offset;
+  while (count >= 8) {
+    if (b != 0) {
+      return false;
+    }
+    ++i;
+    if (i == e.size()) {
+      return true;
+    }
+    b = e[i];
+    count -= 8;
+  }
+  return static_cast<uint8_t>(b << (8 - count)) == 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+// get_last_digit
+//--------------------------------------------------------------------------------------------------
+size_t get_last_digit(basct::cspan<uint8_t> e, size_t radix_log2) noexcept {
+  auto leading_zeros = basbt::count_leading_zeros(e.data(), e.size());
+  return basn::divide_up(e.size() * 8 - leading_zeros, radix_log2);
+}
+
+//--------------------------------------------------------------------------------------------------
+// count_nonzero_digits
+//--------------------------------------------------------------------------------------------------
+size_t count_nonzero_digits(basct::cspan<uint8_t> e, size_t radix_log2) noexcept {
+  size_t res = 0;
+  auto last_digit = get_last_digit(e, radix_log2);
+  for (size_t digit_index = 0; digit_index < last_digit; ++digit_index) {
+    res += static_cast<size_t>(!is_digit_zero(e, radix_log2, digit_index));
+  }
+  return res;
+}
+
+//--------------------------------------------------------------------------------------------------
+// count_num_digits
+//--------------------------------------------------------------------------------------------------
+size_t count_num_digits(basct::cspan<uint8_t> e, size_t radix_log2) noexcept {
+  auto t = e.size() * 8 - basbt::count_leading_zeros(e.data(), e.size());
+  return basn::divide_up(t, radix_log2);
+}
+} // namespace sxt::mtxb

--- a/sxt/multiexp/base/digit_utility.h
+++ b/sxt/multiexp/base/digit_utility.h
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// extract_digit
+//--------------------------------------------------------------------------------------------------
+void extract_digit(basct::span<uint8_t> digit, basct::cspan<uint8_t> e, size_t radix_log2,
+                   size_t digit_index) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// is_digit_zero
+//--------------------------------------------------------------------------------------------------
+bool is_digit_zero(basct::cspan<uint8_t> e, size_t radix_log2, size_t digit_index) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// get_last_digit
+//--------------------------------------------------------------------------------------------------
+size_t get_last_digit(basct::cspan<uint8_t> e, size_t radix_log2) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// count_nonzero_digits
+//--------------------------------------------------------------------------------------------------
+size_t count_nonzero_digits(basct::cspan<uint8_t> e, size_t radix_log2) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// count_num_digits
+//--------------------------------------------------------------------------------------------------
+size_t count_num_digits(basct::cspan<uint8_t> e, size_t radix_log2) noexcept;
+} // namespace sxt::mtxb

--- a/sxt/multiexp/base/digit_utility.t.cc
+++ b/sxt/multiexp/base/digit_utility.t.cc
@@ -1,0 +1,140 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/digit_utility.h"
+
+#include <array>
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt::mtxb;
+
+TEST_CASE("we can extract digits given a radix that's a power of two") {
+  SECTION("we can extract digits from a byte using a radix of 2^8") {
+    uint8_t val[] = {0b10};
+    uint8_t digit[1];
+    extract_digit(digit, val, 8, 0);
+    REQUIRE(digit[0] == 0b10);
+  }
+
+  SECTION("we can extract digits from a byte with a radix less than 2^8") {
+    uint8_t val[] = {0b10110011};
+    uint8_t digit[1];
+
+    extract_digit(digit, val, 3, 0);
+    REQUIRE(digit[0] == 0b011);
+
+    extract_digit(digit, val, 3, 1);
+    REQUIRE(digit[0] == 0b110);
+
+    extract_digit(digit, val, 3, 2);
+    REQUIRE(digit[0] == 0b010);
+  }
+
+  SECTION("we can extract digits from a multi-byte number") {
+    uint8_t val[] = {0b10110011, 0b11001011};
+    uint8_t digit[1];
+
+    extract_digit(digit, val, 8, 0);
+    REQUIRE(digit[0] == val[0]);
+
+    extract_digit(digit, val, 8, 1);
+    REQUIRE(digit[0] == val[1]);
+
+    extract_digit(digit, val, 3, 0);
+    REQUIRE(digit[0] == 0b011);
+
+    extract_digit(digit, val, 3, 1);
+    REQUIRE(digit[0] == 0b110);
+
+    extract_digit(digit, val, 3, 2);
+    REQUIRE(digit[0] == 0b110);
+
+    extract_digit(digit, val, 3, 3);
+    REQUIRE(digit[0] == 0b101);
+
+    extract_digit(digit, val, 3, 4);
+    REQUIRE(digit[0] == 0b100);
+
+    extract_digit(digit, val, 3, 5);
+    REQUIRE(digit[0] == 0b001);
+  }
+
+  SECTION("we can extract digits of size greater than a byte") {
+    uint8_t val[] = {0b10110011, 0b11001011};
+    uint8_t digit[2];
+
+    extract_digit(digit, val, 9, 0);
+    REQUIRE(digit[0] == val[0]);
+    REQUIRE(digit[1] == 0b1);
+
+    extract_digit(digit, val, 9, 1);
+    REQUIRE(digit[0] == 0b1100101);
+    REQUIRE(digit[1] == 0);
+  }
+
+  SECTION("we can exract a digit of the maximum size") {
+    uint8_t val[] = {0b10110011, 0b11001011};
+    uint8_t digit[2];
+
+    extract_digit(digit, val, 16, 0);
+    REQUIRE(digit[0] == val[0]);
+    REQUIRE(digit[1] == val[1]);
+  }
+}
+
+TEST_CASE("we can determine if a digit is zero") {
+  SECTION("we handle a zero exponent of a single byte") {
+    uint8_t val[] = {0};
+    REQUIRE(is_digit_zero(val, 8, 0));
+    REQUIRE(is_digit_zero(val, 1, 0));
+    REQUIRE(is_digit_zero(val, 1, 1));
+    REQUIRE(is_digit_zero(val, 7, 1));
+    REQUIRE(is_digit_zero(val, 9, 0));
+  }
+
+  SECTION("we handle a single byte exponent of 1") {
+    uint8_t val[] = {1};
+    REQUIRE(!is_digit_zero(val, 8, 0));
+    REQUIRE(!is_digit_zero(val, 7, 0));
+    REQUIRE(is_digit_zero(val, 7, 1));
+    REQUIRE(!is_digit_zero(val, 9, 0));
+  }
+
+  SECTION("we handle two bytes") {
+    uint8_t val[] = {0, 1};
+    REQUIRE(!is_digit_zero(val, 9, 0));
+    REQUIRE(is_digit_zero(val, 9, 1));
+
+    val[1] = 0b10000000;
+    REQUIRE(!is_digit_zero(val, 16, 0));
+    REQUIRE(is_digit_zero(val, 15, 0));
+  }
+}
+
+TEST_CASE("we can count the number of digits in a number") {
+  SECTION("we correctly count zero digits") {
+    REQUIRE(count_num_digits(std::array<uint8_t, 1>{0}, 2) == 0);
+  }
+
+  SECTION("we correctly count a single digit") {
+    REQUIRE(count_num_digits(std::array<uint8_t, 1>{1}, 2) == 1);
+  }
+
+  SECTION("we correctly count the maximum number of digits") {
+    REQUIRE(count_num_digits(std::array<uint8_t, 1>{255}, 2) == 4);
+  }
+}

--- a/sxt/multiexp/base/exponent_sequence.cc
+++ b/sxt/multiexp/base/exponent_sequence.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/exponent_sequence.h"

--- a/sxt/multiexp/base/exponent_sequence.h
+++ b/sxt/multiexp/base/exponent_sequence.h
@@ -1,0 +1,43 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// exponent_sequence
+//--------------------------------------------------------------------------------------------------
+struct exponent_sequence {
+  // the number of bytes used to represent an element in the sequence
+  // element_nbytes must be a power of 2 and must satisfy
+  //    1 <= element_nbytes <= 32
+  uint8_t element_nbytes = 0;
+
+  // the number of elements in the sequence
+  uint64_t n = 0;
+
+  // pointer to the data for the sequence of elements where there are n elements
+  // in the sequence and each element encodes a number of element_nbytes bytes
+  // represented in the little endian format
+  const uint8_t* data = nullptr;
+
+  // whether the elements are signed
+  // Note: if signed, then element_nbytes must be <= 16
+  int is_signed = 0;
+};
+} // namespace sxt::mtxb

--- a/sxt/multiexp/base/exponent_sequence_utility.cc
+++ b/sxt/multiexp/base/exponent_sequence_utility.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/exponent_sequence_utility.h"

--- a/sxt/multiexp/base/exponent_sequence_utility.h
+++ b/sxt/multiexp/base/exponent_sequence_utility.h
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include "sxt/multiexp/base/exponent_sequence.h"
+
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// to_exponent_sequence
+//--------------------------------------------------------------------------------------------------
+template <class Cont, class T = std::remove_cvref_t<decltype(*std::declval<const Cont>().data())>>
+exponent_sequence to_exponent_sequence(const Cont& cont) noexcept
+  requires requires {
+    { cont.data() } -> std::convertible_to<const T*>;
+    { cont.size() } -> std::convertible_to<uint64_t>;
+  }
+{
+  static_assert(sizeof(T) <= 32, "element is too large");
+  const T* data = cont.data();
+  int is_signed = 0;
+  if constexpr (std::is_signed_v<T>) {
+    is_signed = 1;
+  }
+  return exponent_sequence{
+      .element_nbytes = sizeof(T),
+      .n = cont.size(),
+      .data = reinterpret_cast<const uint8_t*>(data),
+      .is_signed = is_signed,
+  };
+}
+} // namespace sxt::mtxb

--- a/sxt/multiexp/base/generator_utility.cc
+++ b/sxt/multiexp/base/generator_utility.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/generator_utility.h"

--- a/sxt/multiexp/base/generator_utility.h
+++ b/sxt/multiexp/base/generator_utility.h
@@ -1,0 +1,48 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <iostream>
+
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/error/assert.h"
+
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// filter_generators
+//--------------------------------------------------------------------------------------------------
+template <class T>
+void filter_generators(basct::span<T> dst, basct::cspan<T> src,
+                       const basct::blob_array& masks) noexcept {
+  SXT_DEBUG_ASSERT(dst.size() <= src.size() && src.size() == masks.size());
+  if (dst.size() == src.size()) {
+    std::copy(src.begin(), src.end(), dst.begin());
+    return;
+  }
+  size_t out_index = 0;
+  for (size_t i = 0; i < src.size(); ++i) {
+    auto mask = masks[i];
+    if (std::all_of(mask.begin(), mask.end(), [](uint8_t b) noexcept { return b == 0; })) {
+      continue;
+    }
+    SXT_DEBUG_ASSERT(out_index < dst.size());
+    dst[out_index++] = src[i];
+  }
+}
+} // namespace sxt::mtxb

--- a/sxt/multiexp/base/generator_utility.t.cc
+++ b/sxt/multiexp/base/generator_utility.t.cc
@@ -1,0 +1,50 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/generator_utility.h"
+
+#include <vector>
+
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::mtxb;
+
+TEST_CASE("we can copy over generators using a mask") {
+  SECTION("we handle the case of all generators being copied") {
+    std::vector<int> v = {1, 2, 3};
+    std::vector<int> res(v.size());
+    basct::blob_array masks(v.size(), 1);
+    masks[0][0] = 1;
+    masks[1][0] = 2;
+    masks[2][0] = 3;
+    filter_generators<int>(res, v, masks);
+    REQUIRE(res == v);
+  }
+
+  SECTION("we don't copy elements where the mask is zero") {
+    std::vector<int> v = {1, 2, 3};
+    std::vector<int> res(2);
+    basct::blob_array masks(v.size(), 1);
+    masks[0][0] = 1;
+    masks[1][0] = 0;
+    masks[2][0] = 1;
+    filter_generators<int>(res, v, masks);
+    std::vector<int> expected = {1, 3};
+    REQUIRE(res == expected);
+  }
+}

--- a/sxt/multiexp/bitset_multiprod/BUILD
+++ b/sxt/multiexp/bitset_multiprod/BUILD
@@ -1,0 +1,46 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "value_cache",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "value_cache_utility",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":value_cache",
+        "//sxt/base/container:span",
+        "//sxt/base/error:assert",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct",
+    test_deps = [
+        ":value_cache_utility",
+        ":test_operator",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":value_cache",
+        "//sxt/base/bit:iteration",
+        "//sxt/base/container:span",
+        "//sxt/base/error:assert",
+    ],
+)
+
+sxt_cc_component(
+    name = "test_operator",
+    with_test = False,
+)

--- a/sxt/multiexp/bitset_multiprod/multiproduct.cc
+++ b/sxt/multiexp/bitset_multiprod/multiproduct.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bitset_multiprod/multiproduct.h"

--- a/sxt/multiexp/bitset_multiprod/multiproduct.h
+++ b/sxt/multiexp/bitset_multiprod/multiproduct.h
@@ -1,0 +1,61 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/bit/iteration.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/multiexp/bitset_multiprod/value_cache.h"
+
+namespace sxt::mtxbmp {
+//--------------------------------------------------------------------------------------------------
+// lookup_or_compute
+//--------------------------------------------------------------------------------------------------
+template <class T, class Op>
+const T& lookup_or_compute(basct::span<T> cache_side, Op op, uint64_t bitset) noexcept {
+  auto& value = cache_side[bitset - 1];
+  if (op.is_set(value)) {
+    return value;
+  }
+  auto index = basbt::consume_next_bit(bitset);
+  op.add_bitwise_entries(value, cache_side[(1ull << index) - 1],
+                         lookup_or_compute(cache_side, op, bitset));
+  return value;
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+template <class T, class Op>
+void compute_multiproduct(T& res, value_cache<T> cache, Op op, uint64_t bitset) noexcept {
+  SXT_DEBUG_ASSERT(bitset != 0);
+  auto half_num_terms = cache.half_num_terms();
+  auto right_bitset = bitset >> half_num_terms;
+  auto left_bitset = bitset ^ (right_bitset << half_num_terms);
+  auto [left_cache, right_cache] = cache.split();
+  if (left_bitset == 0) {
+    res = lookup_or_compute(right_cache, op, right_bitset);
+  } else if (right_bitset == 0) {
+    res = lookup_or_compute(left_cache, op, left_bitset);
+  } else {
+    op.add_bitwise_entries(res, lookup_or_compute(left_cache, op, left_bitset),
+                           lookup_or_compute(right_cache, op, right_bitset));
+  }
+}
+} // namespace sxt::mtxbmp

--- a/sxt/multiexp/bitset_multiprod/multiproduct.t.cc
+++ b/sxt/multiexp/bitset_multiprod/multiproduct.t.cc
@@ -1,0 +1,86 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bitset_multiprod/multiproduct.h"
+
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/bitset_multiprod/test_operator.h"
+#include "sxt/multiexp/bitset_multiprod/value_cache.h"
+#include "sxt/multiexp/bitset_multiprod/value_cache_utility.h"
+
+using namespace sxt;
+using namespace sxt::mtxbmp;
+
+TEST_CASE("we can compute the multiproduct from a bitset") {
+  size_t add_counter = 0;
+  test_operator op{&add_counter};
+
+  std::vector<uint64_t> values = {1, 2, 3, 4, 5};
+  std::vector<uint64_t> cache_data(compute_cache_size(values.size()));
+  value_cache cache{cache_data.data(), values.size()};
+  init_value_cache(cache, op, basct::cspan<uint64_t>{values});
+
+  uint64_t res;
+
+  SECTION("we can compute sums with only a single term") {
+    compute_multiproduct(res, cache, op, 0b1);
+    REQUIRE(res == 1);
+    REQUIRE(add_counter == 0);
+
+    compute_multiproduct(res, cache, op, 0b10);
+    REQUIRE(res == 2);
+    REQUIRE(add_counter == 0);
+
+    compute_multiproduct(res, cache, op, 0b100);
+    REQUIRE(res == 3);
+    REQUIRE(add_counter == 0);
+
+    compute_multiproduct(res, cache, op, 0b10000);
+    REQUIRE(res == 5);
+    REQUIRE(add_counter == 0);
+  }
+
+  SECTION("we can compute products with two terms") {
+    compute_multiproduct(res, cache, op, 0b11);
+    REQUIRE(res == 3);
+    REQUIRE(add_counter == 1);
+
+    add_counter = 0;
+    compute_multiproduct(res, cache, op, 0b101);
+    REQUIRE(res == 4);
+    REQUIRE(add_counter == 1);
+
+    add_counter = 0;
+    compute_multiproduct(res, cache, op, 0b10100);
+    REQUIRE(res == 8);
+    REQUIRE(add_counter == 1);
+  }
+
+  SECTION("we don't recompute values") {
+    compute_multiproduct(res, cache, op, 0b11);
+    compute_multiproduct(res, cache, op, 0b11);
+    REQUIRE(res == 3);
+    REQUIRE(add_counter == 1);
+  }
+
+  SECTION("we can compute products with more than two terms") {
+    compute_multiproduct(res, cache, op, 0b1101);
+    REQUIRE(res == 8);
+    REQUIRE(add_counter == 2);
+  }
+}

--- a/sxt/multiexp/bitset_multiprod/test_operator.cc
+++ b/sxt/multiexp/bitset_multiprod/test_operator.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bitset_multiprod/test_operator.h"

--- a/sxt/multiexp/bitset_multiprod/test_operator.h
+++ b/sxt/multiexp/bitset_multiprod/test_operator.h
@@ -1,0 +1,42 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace sxt::mtxbmp {
+//--------------------------------------------------------------------------------------------------
+// test_operator
+//--------------------------------------------------------------------------------------------------
+class test_operator {
+public:
+  test_operator(size_t* counter) noexcept : counter_{counter} {}
+
+  void mark_unset(uint64_t& value) const noexcept { value = 0; }
+
+  bool is_set(uint64_t value) const noexcept { return value != 0; }
+
+  void add_bitwise_entries(uint64_t& res, uint64_t lhs, uint64_t rhs) const noexcept {
+    ++*counter_;
+    res = lhs + rhs;
+  }
+
+private:
+  size_t* counter_;
+};
+} // namespace sxt::mtxbmp

--- a/sxt/multiexp/bitset_multiprod/value_cache.cc
+++ b/sxt/multiexp/bitset_multiprod/value_cache.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bitset_multiprod/value_cache.h"

--- a/sxt/multiexp/bitset_multiprod/value_cache.h
+++ b/sxt/multiexp/bitset_multiprod/value_cache.h
@@ -1,0 +1,54 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxbmp {
+//--------------------------------------------------------------------------------------------------
+// value_cache
+//--------------------------------------------------------------------------------------------------
+template <class T> class value_cache {
+public:
+  value_cache() noexcept = default;
+
+  value_cache(T* data, size_t num_terms) noexcept : data_{data}, num_terms_{num_terms} {}
+
+  // accessors
+  size_t num_terms() const noexcept { return num_terms_; }
+
+  size_t half_num_terms() const noexcept { return num_terms_ / 2; }
+
+  std::pair<basct::span<T>, basct::span<T>> split() const noexcept {
+    auto left_num_terms = this->half_num_terms();
+    auto left_cache_size = (1ull << left_num_terms) - 1;
+    auto right_num_terms = num_terms_ - left_num_terms;
+    auto right_cache_size = (1ull << right_num_terms) - 1;
+    return {
+        {data_, left_cache_size},
+        {data_ + left_cache_size, right_cache_size},
+    };
+  }
+
+private:
+  T* data_{nullptr};
+  size_t num_terms_{0};
+};
+} // namespace sxt::mtxbmp

--- a/sxt/multiexp/bitset_multiprod/value_cache.t.cc
+++ b/sxt/multiexp/bitset_multiprod/value_cache.t.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bitset_multiprod/value_cache.h"

--- a/sxt/multiexp/bitset_multiprod/value_cache_utility.cc
+++ b/sxt/multiexp/bitset_multiprod/value_cache_utility.cc
@@ -1,0 +1,28 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bitset_multiprod/value_cache_utility.h"
+
+namespace sxt::mtxbmp {
+//--------------------------------------------------------------------------------------------------
+// compute_cache_size
+//--------------------------------------------------------------------------------------------------
+size_t compute_cache_size(size_t num_terms) noexcept {
+  auto left_size = num_terms / 2;
+  auto right_size = num_terms - left_size;
+  return (1 << left_size) + (1 << right_size) - 2;
+}
+} // namespace sxt::mtxbmp

--- a/sxt/multiexp/bitset_multiprod/value_cache_utility.h
+++ b/sxt/multiexp/bitset_multiprod/value_cache_utility.h
@@ -1,0 +1,54 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "sxt/base/error/assert.h"
+#include "sxt/multiexp/bitset_multiprod/value_cache.h"
+
+namespace sxt::mtxbmp {
+//--------------------------------------------------------------------------------------------------
+// compute_cache_size
+//--------------------------------------------------------------------------------------------------
+size_t compute_cache_size(size_t num_terms) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// init_value_cache_side
+//--------------------------------------------------------------------------------------------------
+template <class T, class Op>
+void init_value_cache_side(basct::span<T> cache_side, Op op, basct::cspan<T> terms) noexcept {
+  for (auto& value : cache_side) {
+    op.mark_unset(value);
+  }
+  for (size_t term_index = 0; term_index < terms.size(); ++term_index) {
+    cache_side[(1 << term_index) - 1] = terms[term_index];
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_value_cache
+//--------------------------------------------------------------------------------------------------
+template <class T, class Op>
+void init_value_cache(value_cache<T> cache, Op op, basct::cspan<T> terms) noexcept {
+  SXT_DEBUG_ASSERT(terms.size() == cache.num_terms());
+  auto [left_cache, right_cache] = cache.split();
+  auto left_num_terms = cache.half_num_terms();
+  init_value_cache_side(left_cache, op, terms.subspan(0, left_num_terms));
+  init_value_cache_side(right_cache, op, terms.subspan(left_num_terms));
+}
+} // namespace sxt::mtxbmp

--- a/sxt/multiexp/bitset_multiprod/value_cache_utility.t.cc
+++ b/sxt/multiexp/bitset_multiprod/value_cache_utility.t.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bitset_multiprod/value_cache_utility.h"

--- a/sxt/multiexp/curve/BUILD
+++ b/sxt/multiexp/curve/BUILD
@@ -1,0 +1,128 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "doubling_reduction",
+    test_deps = [
+        "//sxt/curve21/operation:add",
+        "//sxt/curve21/operation:double",
+        "//sxt/curve21/operation:neg",
+        "//sxt/curve21/operation:overload",
+        "//sxt/ristretto/type:literal",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/bit:count",
+        "//sxt/base/bit:span_op",
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/error:assert",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiexponentiation_cpu_driver",
+    test_deps = [
+        ":naive_multiproduct_solver",
+        "//sxt/base/test:unit_test",
+        "//sxt/curve21/operation:add",
+        "//sxt/curve21/operation:double",
+        "//sxt/curve21/operation:neg",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/multiexp/pippenger:multiexponentiation",
+        "//sxt/multiexp/test:multiexponentiation",
+    ],
+    deps = [
+        ":multiproduct_solver",
+        ":multiproducts_combination",
+        "//sxt/base/container:blob_array",
+        "//sxt/base/curve:element",
+        "//sxt/base/error:assert",
+        "//sxt/execution/async:future",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/pippenger:driver",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_bitset_operator",
+    with_test = False,
+    deps = [
+        "//sxt/base/curve:element",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_cpu_driver",
+    test_deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/test:unit_test",
+        "//sxt/curve21/operation:add",
+        "//sxt/curve21/operation:double",
+        "//sxt/curve21/operation:neg",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/multiexp/pippenger_multiprod:multiproduct",
+        "//sxt/multiexp/random:random_multiproduct_descriptor",
+        "//sxt/multiexp/random:random_multiproduct_generation",
+        "//sxt/multiexp/test:curve21_arithmetic",
+        "//sxt/ristretto/random:element",
+    ],
+    deps = [
+        ":multiproduct_bitset_operator",
+        "//sxt/base/container:span_void",
+        "//sxt/base/curve:element",
+        "//sxt/base/error:assert",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/bitset_multiprod:multiproduct",
+        "//sxt/multiexp/bitset_multiprod:value_cache",
+        "//sxt/multiexp/bitset_multiprod:value_cache_utility",
+        "//sxt/multiexp/index:clump2_descriptor",
+        "//sxt/multiexp/index:clump2_marker_utility",
+        "//sxt/multiexp/pippenger_multiprod:driver",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_solver",
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/execution/async:future_fwd",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproducts_combination",
+    with_test = False,
+    deps = [
+        ":doubling_reduction",
+        "//sxt/base/bit:span_op",
+        "//sxt/base/container:blob_array",
+        "//sxt/base/container:span",
+        "//sxt/base/container:stack_array",
+        "//sxt/base/curve:element",
+        "//sxt/base/error:assert",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/management:managed_array_fwd",
+        "//sxt/multiexp/base:exponent_sequence",
+    ],
+)
+
+sxt_cc_component(
+    name = "naive_multiproduct_solver",
+    with_test = False,
+    deps = [
+        ":multiproduct_solver",
+        "//sxt/base/curve:element",
+        "//sxt/execution/async:future",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/base:generator_utility",
+        "//sxt/multiexp/index:index_table",
+    ],
+)

--- a/sxt/multiexp/curve/doubling_reduction.cc
+++ b/sxt/multiexp/curve/doubling_reduction.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/doubling_reduction.h"

--- a/sxt/multiexp/curve/doubling_reduction.h
+++ b/sxt/multiexp/curve/doubling_reduction.h
@@ -1,0 +1,54 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <concepts>
+
+#include "sxt/base/bit/count.h"
+#include "sxt/base/bit/span_op.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/error/assert.h"
+
+namespace sxt::mtxcrv {
+//--------------------------------------------------------------------------------------------------
+// doubling_reduce
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element, class Inputs>
+  requires std::constructible_from<basct::cspan<Element>, Inputs>
+void doubling_reduce(Element& res, basct::cspan<uint8_t> digit_or_all,
+                     const Inputs& inputs_convertible) noexcept {
+  basct::cspan<Element> inputs{inputs_convertible};
+  SXT_DEBUG_ASSERT(!inputs.empty() && inputs.size() == basbt::pop_count(digit_or_all));
+
+  auto input_index = inputs.size();
+  size_t digit_bit_index = 8 * digit_or_all.size() - basbt::count_leading_zeros(digit_or_all) - 1;
+
+  // we manually set the first `input_index`
+  // to prevent one `double` and one `add` operation
+  res = inputs[--input_index];
+
+  // The following implementation uses the formula:
+  // output = 2^{i_0} * a0 + 2^{i_1} * (a1 + 2^{i_2} * (a2 + ..)..),
+  // where i_0 <= i_1 <= i_2 <= ... <= i_n.
+  while (digit_bit_index-- > 0) {
+    double_element(res, res);
+    if (basbt::test_bit(digit_or_all, digit_bit_index)) {
+      add(res, res, inputs[--input_index]);
+    }
+  }
+}
+} // namespace sxt::mtxcrv

--- a/sxt/multiexp/curve/doubling_reduction.t.cc
+++ b/sxt/multiexp/curve/doubling_reduction.t.cc
@@ -1,0 +1,54 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/doubling_reduction.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve21/operation/add.h"
+#include "sxt/curve21/operation/double.h"
+#include "sxt/curve21/operation/neg.h"
+#include "sxt/curve21/operation/overload.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/ristretto/type/literal.h"
+
+using namespace sxt;
+using namespace sxt::mtxcrv;
+using sxt::rstt::operator""_rs;
+
+TEST_CASE("we can perform the doubling reduction step of a multiexponentiation") {
+  c21t::element_p3 res;
+
+  SECTION("we handle a single element") {
+    uint8_t digit_or_all[] = {1};
+    c21t::element_p3 inputs[] = {0x123_rs};
+    doubling_reduce(res, digit_or_all, inputs);
+    REQUIRE(res == inputs[0]);
+  }
+
+  SECTION("we handle a single elements that's doubled") {
+    uint8_t digit_or_all[] = {2};
+    c21t::element_p3 inputs[] = {0x123_rs};
+    doubling_reduce(res, digit_or_all, inputs);
+    REQUIRE(res == 2 * inputs[0]);
+  }
+
+  SECTION("we handle multiple inputs") {
+    uint8_t digit_or_all[] = {3};
+    c21t::element_p3 inputs[] = {0x123_rs, 0x345_rs};
+    doubling_reduce(res, digit_or_all, inputs);
+    REQUIRE(res == 2 * inputs[1] + inputs[0]);
+  }
+}

--- a/sxt/multiexp/curve/multiexponentiation_cpu_driver.cc
+++ b/sxt/multiexp/curve/multiexponentiation_cpu_driver.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/multiexponentiation_cpu_driver.h"

--- a/sxt/multiexp/curve/multiexponentiation_cpu_driver.h
+++ b/sxt/multiexp/curve/multiexponentiation_cpu_driver.h
@@ -1,0 +1,72 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/curve/multiproduct_solver.h"
+#include "sxt/multiexp/curve/multiproducts_combination.h"
+#include "sxt/multiexp/pippenger/driver.h"
+
+namespace sxt::mtxcrv {
+//--------------------------------------------------------------------------------------------------
+// multiexponentiation_cpu_driver
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+class multiexponentiation_cpu_driver final : public mtxpi::driver {
+public:
+  //--------------------------------------------------------------------------------------------------
+  // constructor
+  //--------------------------------------------------------------------------------------------------
+  explicit multiexponentiation_cpu_driver(const multiproduct_solver<Element>* solver) noexcept
+      : solver_{solver} {}
+
+  //--------------------------------------------------------------------------------------------------
+  // compute_multiproduct
+  //--------------------------------------------------------------------------------------------------
+  xena::future<memmg::managed_array<void>>
+  compute_multiproduct(mtxi::index_table&& multiproduct_table, basct::span_cvoid generators,
+                       const basct::blob_array& masks, size_t num_inputs) const noexcept override {
+    auto res = solver_
+                   ->solve(std::move(multiproduct_table),
+                           {static_cast<const Element*>(generators.data()), generators.size()},
+                           masks, num_inputs)
+                   .value();
+    return xena::make_ready_future<memmg::managed_array<void>>(std::move(res));
+  }
+
+  //--------------------------------------------------------------------------------------------------
+  // combine_multiproduct_outputs
+  //--------------------------------------------------------------------------------------------------
+  xena::future<memmg::managed_array<void>> combine_multiproduct_outputs(
+      xena::future<memmg::managed_array<void>>&& multiproduct,
+      basct::blob_array&& output_digit_or_all,
+      basct::cspan<mtxb::exponent_sequence> exponents) const noexcept override {
+    SXT_DEBUG_ASSERT(multiproduct.ready());
+    auto products = std::move(multiproduct.value().as_array<Element>());
+    memmg::managed_array<Element> res(exponents.size());
+    combine_multiproducts<Element>(res, output_digit_or_all, products, exponents);
+    return xena::make_ready_future<memmg::managed_array<void>>(std::move(res));
+  }
+
+private:
+  const multiproduct_solver<Element>* solver_;
+};
+} // namespace sxt::mtxcrv

--- a/sxt/multiexp/curve/multiexponentiation_cpu_driver.t.cc
+++ b/sxt/multiexp/curve/multiexponentiation_cpu_driver.t.cc
@@ -1,0 +1,44 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/multiexponentiation_cpu_driver.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve21/operation/add.h"
+#include "sxt/curve21/operation/double.h"
+#include "sxt/curve21/operation/neg.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/curve/naive_multiproduct_solver.h"
+#include "sxt/multiexp/pippenger/multiexponentiation.h"
+#include "sxt/multiexp/test/multiexponentiation.h"
+
+using namespace sxt;
+using namespace sxt::mtxcrv;
+
+TEST_CASE("we can compute multiexponentiations") {
+  naive_multiproduct_solver<c21t::element_p3> solver;
+  multiexponentiation_cpu_driver<c21t::element_p3> drv{&solver};
+  auto f = [&](basct::cspan<c21t::element_p3> generators,
+               basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+    return mtxpi::compute_multiexponentiation(drv, generators, exponents)
+        .value()
+        .as_array<c21t::element_p3>();
+  };
+  std::mt19937 rng{9873324};
+  mtxtst::exercise_multiexponentiation_fn(rng, f);
+}

--- a/sxt/multiexp/curve/multiproduct_bitset_operator.cc
+++ b/sxt/multiexp/curve/multiproduct_bitset_operator.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/multiproduct_bitset_operator.h"

--- a/sxt/multiexp/curve/multiproduct_bitset_operator.h
+++ b/sxt/multiexp/curve/multiproduct_bitset_operator.h
@@ -1,0 +1,35 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/curve/element.h"
+
+namespace sxt::mtxcrv {
+//--------------------------------------------------------------------------------------------------
+// multiproduct_bitset_operator
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element> class multiproduct_bitset_operator {
+public:
+  void mark_unset(Element& e) const noexcept { mark(e); }
+
+  bool is_set(const Element& e) const noexcept { return is_marked(e); }
+
+  void add_bitwise_entries(Element& res, const Element& lhs, const Element& rhs) const noexcept {
+    add(res, lhs, rhs);
+  }
+};
+} // namespace sxt::mtxcrv

--- a/sxt/multiexp/curve/multiproduct_cpu_driver.cc
+++ b/sxt/multiexp/curve/multiproduct_cpu_driver.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/multiproduct_cpu_driver.h"

--- a/sxt/multiexp/curve/multiproduct_cpu_driver.h
+++ b/sxt/multiexp/curve/multiproduct_cpu_driver.h
@@ -1,0 +1,184 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include "sxt/base/container/span_void.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/bitset_multiprod/multiproduct.h"
+#include "sxt/multiexp/bitset_multiprod/value_cache.h"
+#include "sxt/multiexp/bitset_multiprod/value_cache_utility.h"
+#include "sxt/multiexp/curve/multiproduct_bitset_operator.h"
+#include "sxt/multiexp/index/clump2_descriptor.h"
+#include "sxt/multiexp/index/clump2_marker_utility.h"
+#include "sxt/multiexp/pippenger_multiprod/driver.h"
+
+namespace sxt::mtxcrv {
+//--------------------------------------------------------------------------------------------------
+// multiproduct_cpu_driver
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element> class multiproduct_cpu_driver final : public mtxpmp::driver {
+public:
+  void apply_partition_operation(basct::span_void inout, basct::cspan<uint64_t> partition_markers,
+                                 size_t partition_size) const noexcept override;
+
+  void apply_clump2_operation(basct::span_void inout, basct::cspan<uint64_t> markers,
+                              const mtxi::clump2_descriptor& descriptor) const noexcept override;
+
+  void compute_naive_multiproduct(basct::span_void inout,
+                                  basct::cspan<basct::cspan<uint64_t>> products,
+                                  size_t num_inactive_inputs) const noexcept override;
+
+  void permute_inputs(basct::span_void inout,
+                      basct::cspan<uint64_t> permutation) const noexcept override;
+
+private:
+};
+
+//--------------------------------------------------------------------------------------------------
+// apply_partition_operation
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+void multiproduct_cpu_driver<Element>::apply_partition_operation(
+    basct::span_void inout, basct::cspan<uint64_t> partition_markers,
+    size_t partition_size) const noexcept {
+  auto num_inputs = inout.size();
+  auto num_inputs_p = partition_markers.size();
+
+  basct::span<Element> inputs{static_cast<Element*>(inout.data()), num_inputs};
+  memmg::managed_array<Element> inputs_p(num_inputs_p);
+
+  std::vector<Element> cache_data(mtxbmp::compute_cache_size(partition_size));
+  mtxbmp::value_cache<Element> cache;
+  multiproduct_bitset_operator<Element> op;
+  uint64_t partition_index = static_cast<uint64_t>(-1);
+  for (size_t marker_index = 0; marker_index < num_inputs_p; ++marker_index) {
+    auto marker = partition_markers[marker_index];
+    auto partition_index_p = marker >> partition_size;
+    size_t partition_first = partition_index_p * partition_size;
+    if (partition_index_p != partition_index) {
+      partition_index = partition_index_p;
+      cache = {cache_data.data(), std::min(partition_size, num_inputs - partition_first)};
+      mtxbmp::init_value_cache(
+          cache, op, basct::cspan<Element>{inputs.subspan(partition_first, cache.num_terms())});
+    }
+    auto bitset = marker ^ (partition_index << partition_size);
+    mtxbmp::compute_multiproduct(inputs_p[marker_index], cache, op, bitset);
+  }
+  std::copy_n(inputs_p.data(), inputs_p.size(), inputs.data());
+}
+
+//--------------------------------------------------------------------------------------------------
+// apply_clump2_operation
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+void multiproduct_cpu_driver<Element>::apply_clump2_operation(
+    basct::span_void inout, basct::cspan<uint64_t> markers,
+    const mtxi::clump2_descriptor& descriptor) const noexcept {
+  auto num_inputs = inout.size();
+  auto num_inputs_p = markers.size();
+
+  basct::span<Element> inputs{static_cast<Element*>(inout.data()), num_inputs};
+  memmg::managed_array<Element> inputs_p(num_inputs_p);
+
+  for (size_t marker_index = 0; marker_index < num_inputs_p; ++marker_index) {
+    auto marker = markers[marker_index];
+    uint64_t clump_index, index1, index2;
+    mtxi::unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    auto clump_first = descriptor.size * clump_index;
+    auto reduction = inputs[clump_first + index1];
+
+    SXT_DEBUG_ASSERT(index1 <= index2);
+
+    if (index1 != index2) {
+      add(reduction, reduction, inputs[clump_first + index2]);
+    }
+
+    inputs_p[marker_index] = reduction;
+  }
+
+  std::copy_n(inputs_p.data(), num_inputs_p, inputs.data());
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_naive_multiproduct
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+void multiproduct_cpu_driver<Element>::compute_naive_multiproduct(
+    basct::span_void inout, basct::cspan<basct::cspan<uint64_t>> products,
+    size_t num_inactive_inputs) const noexcept {
+  basct::span<Element> inputs{static_cast<Element*>(inout.data()), inout.size()};
+  memmg::managed_array<Element> outputs(products.size());
+
+  for (auto row : products) {
+    SXT_DEBUG_ASSERT(row.size() >= 2 && row.size() >= 2 + row[1]);
+    auto& output = outputs[row[0]];
+
+    if (row.size() == 2) {
+      output = Element::identity();
+      continue;
+    }
+
+    size_t active_index;
+    auto num_inactive_entries = row[1];
+
+    if (num_inactive_entries > 0) {
+      output = inputs[row[2]];
+      active_index = num_inactive_entries + 2;
+
+      // add inactive entries
+      for (size_t inactive_index = 3; inactive_index < 2 + num_inactive_entries; ++inactive_index) {
+        add(output, output, inputs[row[inactive_index]]);
+      }
+    } else {
+      active_index = 3;
+      output = inputs[num_inactive_inputs + row[2]];
+    }
+
+    // add active entries
+    for (; active_index < row.size(); ++active_index) {
+      add(output, output, inputs[num_inactive_inputs + row[active_index]]);
+    }
+  }
+
+  std::copy_n(outputs.data(), outputs.size(), inputs.data());
+}
+
+//--------------------------------------------------------------------------------------------------
+// permute_inputs
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+void multiproduct_cpu_driver<Element>::permute_inputs(
+    basct::span_void inout, basct::cspan<uint64_t> permutation) const noexcept {
+  auto n = permutation.size();
+  SXT_DEBUG_ASSERT(n <= inout.size());
+
+  memmg::managed_array<Element> inputs_p(n);
+  basct::span<Element> inputs{static_cast<Element*>(inout.data()), n};
+
+  for (size_t index = 0; index < n; ++index) {
+    auto index_p = permutation[index];
+    inputs_p[index] = inputs[index_p];
+  }
+
+  std::copy_n(inputs_p.data(), n, inputs.data());
+}
+} // namespace sxt::mtxcrv

--- a/sxt/multiexp/curve/multiproduct_cpu_driver.t.cc
+++ b/sxt/multiexp/curve/multiproduct_cpu_driver.t.cc
@@ -1,0 +1,201 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/multiproduct_cpu_driver.h"
+
+#include <random>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve21/operation/add.h"
+#include "sxt/curve21/operation/double.h"
+#include "sxt/curve21/operation/neg.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/pippenger_multiprod/multiproduct.h"
+#include "sxt/multiexp/random/random_multiproduct_descriptor.h"
+#include "sxt/multiexp/random/random_multiproduct_generation.h"
+#include "sxt/multiexp/test/curve21_arithmetic.h"
+#include "sxt/ristretto/random/element.h"
+
+using namespace sxt;
+using namespace sxt::mtxcrv;
+
+static void verify_random_example(std::mt19937& rng,
+                                  const mtxrn::random_multiproduct_descriptor& descriptor) {
+  mtxi::index_table products;
+  multiproduct_cpu_driver<c21t::element_p3> drv;
+  size_t num_inputs, num_entries;
+
+  mtxrn::generate_random_multiproduct(products, num_inputs, num_entries, rng, descriptor);
+
+  memmg::managed_array<c21t::element_p3> inout(num_entries);
+  rstrn::generate_random_elements(basct::span<c21t::element_p3>{inout.data(), num_inputs}, rng);
+
+  memmg::managed_array<c21t::element_p3> expected_result(products.num_rows());
+  mtxtst::sum_curve21_elements(expected_result, products.cheader(), inout);
+
+  mtxpmp::compute_multiproduct(inout, products, drv, num_inputs);
+
+  for (size_t index = 0; index < products.num_rows(); ++index) {
+    REQUIRE(inout[index] == expected_result[index]);
+  }
+}
+
+TEST_CASE("we can compute curve21 multiproducts") {
+  std::mt19937 rng{2022};
+  multiproduct_cpu_driver<c21t::element_p3> drv;
+
+  SECTION("we handle the empty case") {
+    memmg::managed_array<c21t::element_p3> inout;
+    mtxi::index_table products;
+
+    mtxpmp::compute_multiproduct(inout, products, drv, 0);
+
+    REQUIRE(inout.empty());
+  }
+
+  SECTION("we handle a multiproduct with a single term") {
+    size_t num_inputs = 1;
+    memmg::managed_array<c21t::element_p3> inout(1);
+    rstrn::generate_random_elements(basct::span<c21t::element_p3>{inout.data(), num_inputs}, rng);
+
+    mtxi::index_table products{{0}};
+
+    memmg::managed_array<c21t::element_p3> expected_result(1);
+    mtxtst::sum_curve21_elements(expected_result, products.cheader(), inout);
+
+    mtxpmp::compute_multiproduct(inout, products, drv, num_inputs);
+
+    REQUIRE(inout == expected_result);
+  }
+
+  SECTION("we handle a single output with multiple terms") {
+    size_t num_inputs = 2;
+    memmg::managed_array<c21t::element_p3> inout(2);
+    rstrn::generate_random_elements(basct::span<c21t::element_p3>{inout.data(), num_inputs}, rng);
+
+    mtxi::index_table products{{0, 1}};
+
+    memmg::managed_array<c21t::element_p3> expected_result(1);
+    mtxtst::sum_curve21_elements(expected_result, products.cheader(), inout);
+
+    mtxpmp::compute_multiproduct(inout, products, drv, num_inputs);
+
+    REQUIRE(inout[0] == expected_result[0]);
+  }
+
+  SECTION("we handle a multi-product with two outputs") {
+    size_t num_inputs = 3;
+    memmg::managed_array<c21t::element_p3> inout(5);
+    rstrn::generate_random_elements(basct::span<c21t::element_p3>{inout.data(), num_inputs}, rng);
+
+    mtxi::index_table products{{0, 1, 2}, {0, 2}};
+
+    memmg::managed_array<c21t::element_p3> expected_result(2);
+    mtxtst::sum_curve21_elements(expected_result, products.cheader(), inout);
+
+    mtxpmp::compute_multiproduct(inout, products, drv, num_inputs);
+
+    REQUIRE(inout[0] == expected_result[0]);
+    REQUIRE(inout[1] == expected_result[1]);
+  }
+
+  SECTION("we can handle random multiproducts with only two rows and few entries") {
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 4,
+        .min_num_sequences = 2,
+        .max_num_sequences = 2,
+        .max_num_inputs = 8,
+    };
+
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with two rows and many entries") {
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 20,
+        .min_num_sequences = 2,
+        .max_num_sequences = 2,
+        .max_num_inputs = 20,
+    };
+
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with three rows") {
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 20,
+        .min_num_sequences = 3,
+        .max_num_sequences = 3,
+        .max_num_inputs = 20,
+    };
+
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with multiple rows") {
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 20,
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .max_num_inputs = 20,
+    };
+
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with many rows") {
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 100,
+        .min_num_sequences = 100,
+        .max_num_sequences = 1000,
+        .max_num_inputs = 200,
+    };
+
+    for (int i = 0; i < 5; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with many inputs") {
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1000,
+        .max_sequence_length = 2000,
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .max_num_inputs = 4000,
+    };
+
+    for (int i = 0; i < 10; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+}

--- a/sxt/multiexp/curve/multiproduct_solver.cc
+++ b/sxt/multiexp/curve/multiproduct_solver.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/multiproduct_solver.h"

--- a/sxt/multiexp/curve/multiproduct_solver.h
+++ b/sxt/multiexp/curve/multiproduct_solver.h
@@ -1,0 +1,44 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/execution/async/future_fwd.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::basct {
+class blob_array;
+}
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxcrv {
+//--------------------------------------------------------------------------------------------------
+// multiproduct_solver
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element> class multiproduct_solver {
+public:
+  virtual ~multiproduct_solver() noexcept = default;
+
+  virtual xena::future<memmg::managed_array<Element>> solve(mtxi::index_table&& multiproduct_table,
+                                                            basct::cspan<Element> generators,
+                                                            const basct::blob_array& mask,
+                                                            size_t num_inputs) const noexcept = 0;
+};
+} // namespace sxt::mtxcrv

--- a/sxt/multiexp/curve/multiproducts_combination.cc
+++ b/sxt/multiexp/curve/multiproducts_combination.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/multiproducts_combination.h"

--- a/sxt/multiexp/curve/multiproducts_combination.h
+++ b/sxt/multiexp/curve/multiproducts_combination.h
@@ -1,0 +1,179 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <concepts>
+#include <tuple>
+
+#include "sxt/base/bit/span_op.h"
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/container/stack_array.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/curve/doubling_reduction.h"
+
+namespace sxt::basct {
+class blob_array;
+}
+
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::mtxcrv {
+//--------------------------------------------------------------------------------------------------
+// init_output_products
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+static std::tuple<basct::cspan<Element>, basct::cspan<uint8_t>>
+init_output_products(size_t& product_index, size_t& input_index, basct::span<Element> products,
+                     basct::blob_array& output_digit_or_all, bool is_signed) noexcept {
+  auto digit_or_all = output_digit_or_all[product_index++];
+  size_t digit_count_one = basbt::pop_count(digit_or_all);
+  if (!is_signed) {
+    auto output_products = products.subspan(input_index, digit_count_one);
+    input_index += digit_count_one;
+    return {output_products, digit_or_all};
+  }
+  SXT_STACK_ARRAY(pos_digit_or_all, digit_or_all.size(), uint8_t);
+  std::copy(digit_or_all.begin(), digit_or_all.end(), pos_digit_or_all.begin());
+  auto neg_digit_or_all = output_digit_or_all[product_index++];
+  basbt::or_equal(digit_or_all, neg_digit_or_all);
+  auto pos_digit_count_one = digit_count_one;
+  auto neg_digit_count_one = basbt::pop_count(neg_digit_or_all);
+  digit_count_one = basbt::pop_count(digit_or_all);
+  auto output_products = products.subspan(input_index, digit_count_one);
+  SXT_STACK_ARRAY(pos_products, pos_digit_count_one, Element);
+  std::copy_n(output_products.begin(), pos_digit_count_one, pos_products.begin());
+  auto neg_products = products.subspan(input_index + pos_digit_count_one, neg_digit_count_one);
+  for (auto& e : neg_products) {
+    neg(e, e);
+  }
+  size_t pos_index = 0;
+  size_t neg_index = 0;
+  size_t out_index = 0;
+  basbt::for_each_bit(digit_or_all, [&](size_t bit_index) noexcept {
+    auto is_pos_set = basbt::test_bit(pos_digit_or_all, bit_index);
+    auto is_neg_set = basbt::test_bit(neg_digit_or_all, bit_index);
+    if (is_pos_set && is_neg_set) {
+      add(output_products[out_index++], pos_products[pos_index++], neg_products[neg_index++]);
+    } else if (is_pos_set) {
+      output_products[out_index++] = pos_products[pos_index++];
+    } else {
+      output_products[out_index++] = neg_products[neg_index++];
+    }
+  });
+  input_index += pos_digit_count_one + neg_digit_count_one;
+  return {output_products, digit_or_all};
+}
+
+//--------------------------------------------------------------------------------------------------
+// fold_multiproducts
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+void fold_multiproducts(memmg::managed_array<Element>& products, basct::span<uint8_t> digit_or_all,
+                        basct::cspan<Element> products_p,
+                        basct::cspan<uint8_t> digit_or_all_p) noexcept {
+  auto num_bytes = digit_or_all.size();
+  // clang-format off
+  SXT_DEBUG_ASSERT(
+      digit_or_all.size() == num_bytes &&
+      basbt::pop_count(digit_or_all) == products.size() &&
+      digit_or_all_p.size() == num_bytes &&
+      basbt::pop_count(digit_or_all_p) == products_p.size()
+  );
+  // clang-format on
+  SXT_STACK_ARRAY(digit_or_all_pp, num_bytes, uint8_t);
+  std::copy(digit_or_all.begin(), digit_or_all.end(), digit_or_all_pp.begin());
+  basbt::or_equal(digit_or_all_pp, digit_or_all_p);
+  auto bit_count = basbt::pop_count(digit_or_all_pp);
+  size_t index = 0;
+  size_t index_p = 0;
+  size_t index_pp = 0;
+  memmg::managed_array<Element> products_pp(bit_count, products.get_allocator());
+  basbt::for_each_bit(digit_or_all_pp, [&](size_t bit_index) noexcept {
+    auto is_set = basbt::test_bit(digit_or_all, bit_index);
+    auto is_set_p = basbt::test_bit(digit_or_all_p, bit_index);
+    SXT_DEBUG_ASSERT(is_set || is_set_p);
+    if (is_set && is_set_p) {
+      add(products_pp[index_pp++], products[index++], products_p[index_p++]);
+    } else if (is_set) {
+      products_pp[index_pp++] = products[index++];
+    } else {
+      products_pp[index_pp++] = products_p[index_p++];
+    }
+  });
+  std::copy(digit_or_all_pp.begin(), digit_or_all_pp.end(), digit_or_all.begin());
+  products = std::move(products_pp);
+}
+
+//--------------------------------------------------------------------------------------------------
+// combine_multiproducts
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+void combine_multiproducts(basct::span<Element> outputs,
+                           const basct::blob_array& output_digit_or_all,
+                           basct::cspan<Element> products) noexcept {
+  size_t input_index = 0;
+  for (size_t output_index = 0; output_index < output_digit_or_all.size(); ++output_index) {
+    auto digit_or_all = output_digit_or_all[output_index];
+    int digit_count_one = basbt::pop_count(digit_or_all);
+    if (digit_count_one == 0) {
+      outputs[output_index] = Element::identity();
+      continue;
+    }
+    Element output;
+    SXT_DEBUG_ASSERT(input_index + digit_count_one <= products.size());
+    doubling_reduce(
+        output, digit_or_all,
+        basct::cspan<Element>{&products[input_index], static_cast<size_t>(digit_count_one)});
+    input_index += digit_count_one;
+    outputs[output_index] = output;
+  }
+}
+
+template <bascrv::element Element>
+void combine_multiproducts(basct::span<Element> outputs, basct::blob_array& output_digit_or_all,
+                           basct::span<Element> products,
+                           basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+  auto num_sequences = exponents.size();
+  // clang-format off
+  SXT_DEBUG_ASSERT(
+      outputs.size() == num_sequences && 
+      exponents.size() == num_sequences
+  );
+  // clang-format on
+  size_t product_index = 0;
+  size_t input_index = 0;
+  for (size_t sequence_index = 0; sequence_index < exponents.size(); ++sequence_index) {
+    auto sequence = exponents[sequence_index];
+    auto [output_products, digit_or_all] =
+        init_output_products<Element>(product_index, input_index, products, output_digit_or_all,
+                                      static_cast<bool>(sequence.is_signed));
+    if (output_products.empty()) {
+      outputs[sequence_index] = Element::identity();
+      continue;
+    }
+    doubling_reduce(outputs[sequence_index], digit_or_all, output_products);
+  }
+}
+} // namespace sxt::mtxcrv

--- a/sxt/multiexp/curve/naive_multiproduct_solver.cc
+++ b/sxt/multiexp/curve/naive_multiproduct_solver.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve/naive_multiproduct_solver.h"

--- a/sxt/multiexp/curve/naive_multiproduct_solver.h
+++ b/sxt/multiexp/curve/naive_multiproduct_solver.h
@@ -1,0 +1,62 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/curve/element.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/base/generator_utility.h"
+#include "sxt/multiexp/curve/multiproduct_solver.h"
+#include "sxt/multiexp/index/index_table.h"
+
+namespace sxt::mtxcrv {
+//--------------------------------------------------------------------------------------------------
+// naive_multiproduct_solver
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element Element>
+class naive_multiproduct_solver final : public multiproduct_solver<Element> {
+public:
+  // multiproduct_solver
+  xena::future<memmg::managed_array<Element>> solve(mtxi::index_table&& multiproduct_table,
+                                                    basct::cspan<Element> generators,
+                                                    const basct::blob_array& masks,
+                                                    size_t num_inputs) const noexcept override {
+    memmg::managed_array<Element> inputs_data;
+    basct::cspan<Element> inputs;
+    if (num_inputs == generators.size()) {
+      inputs = generators;
+    } else {
+      inputs_data = memmg::managed_array<Element>(num_inputs);
+      mtxb::filter_generators<Element>(inputs_data, generators, masks);
+      inputs = inputs_data;
+    }
+    memmg::managed_array<Element> res(multiproduct_table.num_rows());
+    for (size_t row_index = 0; row_index < multiproduct_table.num_rows(); ++row_index) {
+      auto products = multiproduct_table.header()[row_index];
+      SXT_DEBUG_ASSERT(products.size() > 2);
+      Element output = inputs[products[2]];
+      for (size_t input_index = 3; input_index < products.size(); ++input_index) {
+        auto input = products[input_index];
+        add(output, output, inputs[input]);
+      }
+      res[row_index] = output;
+    }
+
+    return xena::make_ready_future(std::move(res));
+  }
+};
+} // namespace sxt::mtxcrv

--- a/sxt/multiexp/curve21/BUILD
+++ b/sxt/multiexp/curve21/BUILD
@@ -1,0 +1,97 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "multiproduct",
+    impl_deps = [
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/algorithm/base:gather_mapper",
+        "//sxt/curve21/operation:accumulator",
+        "//sxt/curve21/operation:neg",
+        "//sxt/execution/async:future",
+        "//sxt/multiexp/multiproduct_gpu:multiproduct",
+    ],
+    is_cuda = True,
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/type:raw_stream",
+        "//sxt/execution/async:future_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiexponentiation",
+    impl_deps = [
+        ":multiproduct",
+        ":pippenger_multiproduct_solver",
+        "//sxt/base/container:blob_array",
+        "//sxt/curve21/operation:accumulator",
+        "//sxt/execution/async:future",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/curve:multiexponentiation_cpu_driver",
+        "//sxt/multiexp/curve:multiproducts_combination",
+        "//sxt/multiexp/pippenger:multiexponentiation",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:event",
+        "//sxt/base/device:event_utility",
+        "//sxt/base/iterator:index_range",
+        "//sxt/memory/resource:device_resource",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/multiexp/pippenger:multiproduct_decomposition_gpu",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/execution/async:coroutine",
+        "//sxt/execution/device:device_viewable",
+        "//sxt/execution/device:for_each",
+        "//sxt/base/device:stream",
+    ],
+    test_deps = [
+        "//sxt/memory/management:managed_array",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/base/test:unit_test",
+        "//sxt/multiexp/test:multiexponentiation",
+        "//sxt/memory/resource:managed_device_resource",
+        "//sxt/execution/async:future",
+        "//sxt/execution/schedule:scheduler",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/execution/async:future_fwd",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "pippenger_multiproduct_solver",
+    impl_deps = [
+        "//sxt/base/container:blob_array",
+        "//sxt/execution/async:future",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/curve:multiproduct_cpu_driver",
+        "//sxt/multiexp/pippenger_multiprod:multiproduct",
+        "//sxt/multiexp/pippenger_multiprod:active_offset",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/multiexp/index:reindex",
+        "//sxt/multiexp/base:generator_utility",
+    ],
+    test_deps = [
+        "//sxt/base/container:blob_array",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/curve21/operation:overload",
+        "//sxt/ristretto/type:literal",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/execution/async:future",
+    ],
+    deps = [
+        "//sxt/curve21/operation:add",
+        "//sxt/curve21/operation:double",
+        "//sxt/curve21/operation:neg",
+        "//sxt/multiexp/curve:multiproduct_solver",
+    ],
+)

--- a/sxt/multiexp/curve21/multiexponentiation.cc
+++ b/sxt/multiexp/curve21/multiexponentiation.cc
@@ -48,7 +48,7 @@ namespace sxt::mtxc21 {
 //--------------------------------------------------------------------------------------------------
 static xena::future<> async_compute_multiexponentiation_impl(
     memmg::managed_array<c21t::element_p3>& products, basct::span<uint8_t> or_all,
-    const xendv::event_future<basct::cspan<c21t::element_p3>>& generators_event,
+    xendv::event_future<basct::cspan<c21t::element_p3>>& generators_event,
     mtxb::exponent_sequence exponents) noexcept {
   auto num_bytes = exponents.element_nbytes;
   basdv::stream stream;

--- a/sxt/multiexp/curve21/multiexponentiation.cc
+++ b/sxt/multiexp/curve21/multiexponentiation.cc
@@ -1,0 +1,169 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve21/multiexponentiation.h"
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/device/event.h"
+#include "sxt/base/device/event_utility.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/iterator/index_range.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/execution/async/coroutine.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/device/device_viewable.h"
+#include "sxt/execution/device/for_each.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/memory/resource/device_resource.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/curve/multiexponentiation_cpu_driver.h"
+#include "sxt/multiexp/curve/multiproducts_combination.h"
+#include "sxt/multiexp/curve21/multiproduct.h"
+#include "sxt/multiexp/curve21/pippenger_multiproduct_solver.h"
+#include "sxt/multiexp/pippenger/multiexponentiation.h"
+#include "sxt/multiexp/pippenger/multiproduct_decomposition_gpu.h"
+
+namespace sxt::mtxc21 {
+//--------------------------------------------------------------------------------------------------
+// async_compute_multiexponentiation_impl
+//--------------------------------------------------------------------------------------------------
+static xena::future<> async_compute_multiexponentiation_impl(
+    memmg::managed_array<c21t::element_p3>& products, basct::span<uint8_t> or_all,
+    const xendv::event_future<basct::cspan<c21t::element_p3>>& generators_event,
+    mtxb::exponent_sequence exponents) noexcept {
+  auto num_bytes = exponents.element_nbytes;
+  basdv::stream stream;
+  memr::async_device_resource resource{stream};
+  bool is_signed = static_cast<bool>(exponents.is_signed);
+
+  // decompose exponents
+  memmg::managed_array<unsigned> indexes{&resource};
+  memmg::managed_array<unsigned> product_sizes(num_bytes * 8u);
+  co_await mtxpi::compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+  if (indexes.empty()) {
+    co_return;
+  }
+
+  // or_all_p
+  std::vector<uint8_t> or_all_p(num_bytes);
+  size_t bit_index = 0;
+  for (size_t byte_index = 0; byte_index < num_bytes; ++byte_index) {
+    uint8_t val = 0;
+    for (int i = 0; i < 8; ++i) {
+      val |= static_cast<uint8_t>(product_sizes[bit_index++] > 0) << i;
+    }
+    or_all_p[byte_index] = val;
+  }
+
+  // compute multiproduct
+  auto last = std::remove(product_sizes.begin(), product_sizes.end(), 0u);
+  product_sizes.shrink(static_cast<size_t>(std::distance(product_sizes.begin(), last)));
+  memmg::managed_array<c21t::element_p3> products_p(product_sizes.size());
+  xendv::synchronize_event(stream, generators_event);
+  co_await async_compute_multiproduct(products_p, stream, generators_event.value(), indexes,
+                                      product_sizes, is_signed);
+  mtxcrv::fold_multiproducts<c21t::element_p3>(products, or_all, products_p, or_all_p);
+}
+
+//--------------------------------------------------------------------------------------------------
+// async_compute_multiexponentiation_partial
+//--------------------------------------------------------------------------------------------------
+static xena::future<> async_compute_multiexponentiation_partial(
+    basct::span<basct::blob_array> or_alls,
+    basct::span<memmg::managed_array<c21t::element_p3>> products,
+    basct::cspan<c21t::element_p3> generators, basct::cspan<mtxb::exponent_sequence> exponents,
+    basit::index_range rng) noexcept {
+  auto num_outputs = or_alls.size();
+  // set up generators
+  memmg::managed_array<c21t::element_p3> generators_data{memr::get_device_resource()};
+  auto generators_event = xendv::make_active_device_viewable(
+      generators_data,
+      generators.subspan(static_cast<size_t>(rng.a()), static_cast<size_t>(rng.size())));
+  std::vector<xena::future<>> futs;
+  futs.reserve(num_outputs);
+  for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
+    auto output_exponents = exponents[output_index];
+    if (static_cast<size_t>(rng.a()) >= output_exponents.n) {
+      continue;
+    }
+    output_exponents.data += output_exponents.element_nbytes * rng.a();
+    output_exponents.n = std::min(static_cast<size_t>(rng.size()), output_exponents.n - rng.a());
+    auto fut = async_compute_multiexponentiation_impl(
+        products[output_index], or_alls[output_index][0], generators_event, output_exponents);
+    futs.emplace_back(std::move(fut));
+  }
+
+  for (auto& fut : futs) {
+    co_await std::move(fut);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+memmg::managed_array<c21t::element_p3>
+compute_multiexponentiation(basct::cspan<c21t::element_p3> generators,
+                            basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+  pippenger_multiproduct_solver solver;
+  mtxcrv::multiexponentiation_cpu_driver<c21t::element_p3> driver{&solver};
+  // Note: the cpu driver is non-blocking so that the future upon return the future is
+  // available
+  return mtxpi::compute_multiexponentiation(driver,
+                                            {static_cast<const void*>(generators.data()),
+                                             generators.size(), sizeof(c21t::element_p3)},
+                                            exponents)
+      .value()
+      .as_array<c21t::element_p3>();
+}
+
+//--------------------------------------------------------------------------------------------------
+// async_compute_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+xena::future<memmg::managed_array<c21t::element_p3>>
+async_compute_multiexponentiation(basct::cspan<c21t::element_p3> generators,
+                                  basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+  auto num_outputs = exponents.size();
+  std::vector<basct::blob_array> or_alls;
+  or_alls.reserve(num_outputs);
+  for (auto& exponent_sequence : exponents) {
+    or_alls.emplace_back(1, exponent_sequence.element_nbytes);
+  }
+  std::vector<memmg::managed_array<c21t::element_p3>> products(num_outputs);
+  co_await xendv::concurrent_for_each(basit::index_range{0, generators.size()},
+                                      [&](const basit::index_range& rng) noexcept {
+                                        return async_compute_multiexponentiation_partial(
+                                            or_alls, products, generators, exponents, rng);
+                                      });
+  memmg::managed_array<c21t::element_p3> res(num_outputs);
+  for (size_t i = 0; i < num_outputs; ++i) {
+    mtxcrv::combine_multiproducts<c21t::element_p3>({&res[i], 1}, or_alls[i], products[i]);
+  }
+  co_return res;
+}
+
+xena::future<c21t::element_p3>
+async_compute_multiexponentiation(basct::cspan<c21t::element_p3> generators,
+                                  const mtxb::exponent_sequence& exponents) noexcept {
+  auto res = co_await async_compute_multiexponentiation(generators, {&exponents, 1});
+  co_return res[0];
+}
+} // namespace sxt::mtxc21

--- a/sxt/multiexp/curve21/multiexponentiation.h
+++ b/sxt/multiexp/curve21/multiexponentiation.h
@@ -1,0 +1,48 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/execution/async/future_fwd.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::c21t {
+struct element_p3;
+}
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::mtxc21 {
+//--------------------------------------------------------------------------------------------------
+// compute_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+memmg::managed_array<c21t::element_p3>
+compute_multiexponentiation(basct::cspan<c21t::element_p3> generators,
+                            basct::cspan<mtxb::exponent_sequence> exponents) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// async_compute_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+xena::future<memmg::managed_array<c21t::element_p3>>
+async_compute_multiexponentiation(basct::cspan<c21t::element_p3> generators,
+                                  basct::cspan<mtxb::exponent_sequence> exponents) noexcept;
+
+xena::future<c21t::element_p3>
+async_compute_multiexponentiation(basct::cspan<c21t::element_p3> generators,
+                                  const mtxb::exponent_sequence& exponents) noexcept;
+} // namespace sxt::mtxc21

--- a/sxt/multiexp/curve21/multiexponentiation.t.cc
+++ b/sxt/multiexp/curve21/multiexponentiation.t.cc
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve21/multiexponentiation.h"
+
+#include <algorithm>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/test/multiexponentiation.h"
+
+using namespace sxt;
+using namespace sxt::mtxc21;
+
+TEST_CASE("we can compute multiexponentiations") {
+  auto f = [](basct::cspan<c21t::element_p3> generators,
+              basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+    return compute_multiexponentiation(generators, exponents);
+  };
+  std::mt19937 rng{97834978};
+  mtxtst::exercise_multiexponentiation_fn(rng, f);
+}
+
+TEST_CASE("we can compute async multiexponentiations") {
+  auto f = [](basct::cspan<c21t::element_p3> generators,
+              basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+    auto fut = async_compute_multiexponentiation(generators, exponents);
+    xens::get_scheduler().run();
+    return memmg::managed_array<c21t::element_p3>{std::move(fut.value())};
+  };
+  std::mt19937 rng{893345};
+  mtxtst::exercise_multiexponentiation_fn(rng, f);
+}

--- a/sxt/multiexp/curve21/multiproduct.cc
+++ b/sxt/multiexp/curve21/multiproduct.cc
@@ -1,0 +1,76 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve21/multiproduct.h"
+
+#include "sxt/algorithm/base/gather_mapper.h"
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/curve21/operation/accumulator.h"
+#include "sxt/curve21/operation/neg.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/multiexp/multiproduct_gpu/multiproduct.h"
+
+namespace sxt::mtxc21 {
+//--------------------------------------------------------------------------------------------------
+// signed_mapper
+//--------------------------------------------------------------------------------------------------
+namespace {
+class signed_mapper {
+public:
+  using value_type = c21t::element_p3;
+
+  CUDA_CALLABLE signed_mapper(const c21t::element_p3* generators, const unsigned* indexes) noexcept
+      : generators_{generators}, indexes_{indexes} {}
+
+  CUDA_CALLABLE void map_index(c21t::element_p3& val, unsigned int index) const noexcept {
+    constexpr auto sign_bit = 1u << 31;
+    auto i = indexes_[index];
+    auto is_neg = static_cast<unsigned>((i & sign_bit) != 0);
+    i = i & ~sign_bit;
+    val = generators_[i];
+    c21o::cneg(val, is_neg);
+  }
+
+  CUDA_CALLABLE c21t::element_p3 map_index(unsigned int index) const noexcept {
+    c21t::element_p3 res;
+    this->map_index(res, index);
+    return res;
+  }
+
+private:
+  const c21t::element_p3* generators_;
+  const unsigned* indexes_;
+};
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+// async_compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+xena::future<> async_compute_multiproduct(basct::span<c21t::element_p3> products,
+                                          const basdv::stream& stream,
+                                          basct::cspan<c21t::element_p3> generators,
+                                          basct::cspan<unsigned> indexes,
+                                          basct::cspan<unsigned> product_sizes,
+                                          bool is_signed) noexcept {
+  if (!is_signed) {
+    using Mapper = algb::gather_mapper<c21t::element_p3>;
+    return mtxmpg::compute_multiproduct<c21o::accumulator, Mapper>(products, stream, generators,
+                                                                   indexes, product_sizes);
+  }
+  return mtxmpg::compute_multiproduct<c21o::accumulator, signed_mapper>(
+      products, stream, generators, indexes, product_sizes);
+}
+} // namespace sxt::mtxc21

--- a/sxt/multiexp/curve21/multiproduct.h
+++ b/sxt/multiexp/curve21/multiproduct.h
@@ -1,0 +1,40 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/execution/async/future_fwd.h"
+
+namespace sxt::c21t {
+struct element_p3;
+}
+
+namespace sxt::basdv {
+class stream;
+}
+
+namespace sxt::mtxc21 {
+//--------------------------------------------------------------------------------------------------
+// async_compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+xena::future<> async_compute_multiproduct(basct::span<c21t::element_p3> products,
+                                          const basdv::stream& stream,
+                                          basct::cspan<c21t::element_p3> generators,
+                                          basct::cspan<unsigned> indexes,
+                                          basct::cspan<unsigned> product_sizes,
+                                          bool is_signed) noexcept;
+} // namespace sxt::mtxc21

--- a/sxt/multiexp/curve21/pippenger_multiproduct_solver.cc
+++ b/sxt/multiexp/curve21/pippenger_multiproduct_solver.cc
@@ -1,0 +1,54 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve21/pippenger_multiproduct_solver.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/base/generator_utility.h"
+#include "sxt/multiexp/curve/multiproduct_cpu_driver.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/index/reindex.h"
+#include "sxt/multiexp/pippenger_multiprod/active_offset.h"
+#include "sxt/multiexp/pippenger_multiprod/multiproduct.h"
+
+namespace sxt::mtxc21 {
+//--------------------------------------------------------------------------------------------------
+// solve
+//--------------------------------------------------------------------------------------------------
+xena::future<memmg::managed_array<c21t::element_p3>> pippenger_multiproduct_solver::solve(
+    mtxi::index_table&& multiproduct_table, basct::cspan<c21t::element_p3> generators,
+    const basct::blob_array& masks, size_t num_inputs) const noexcept {
+  size_t entry_count = 0;
+  for (auto row : multiproduct_table.cheader()) {
+    SXT_DEBUG_ASSERT(row.size() > 2, "all outputs should have at least a single product");
+    entry_count += row.size() - 2;
+  }
+  SXT_DEBUG_ASSERT(entry_count >= num_inputs);
+  memmg::managed_array<c21t::element_p3> res(entry_count);
+  mtxb::filter_generators<c21t::element_p3>(basct::span<c21t::element_p3>{res.data(), num_inputs},
+                                            generators, masks);
+  mtxcrv::multiproduct_cpu_driver<c21t::element_p3> driver;
+  mtxpmp::compute_multiproduct(res, multiproduct_table.header(), driver, num_inputs);
+  return xena::make_ready_future(std::move(res));
+}
+} // namespace sxt::mtxc21

--- a/sxt/multiexp/curve21/pippenger_multiproduct_solver.h
+++ b/sxt/multiexp/curve21/pippenger_multiproduct_solver.h
@@ -1,0 +1,39 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/curve21/operation/add.h"
+#include "sxt/curve21/operation/double.h"
+#include "sxt/curve21/operation/neg.h"
+#include "sxt/multiexp/curve/multiproduct_solver.h"
+
+namespace sxt::c21t {
+struct element_p3;
+}
+
+namespace sxt::mtxc21 {
+//--------------------------------------------------------------------------------------------------
+// pippenger_multiproduct_solver
+//--------------------------------------------------------------------------------------------------
+class pippenger_multiproduct_solver final : public mtxcrv::multiproduct_solver<c21t::element_p3> {
+public:
+  // multiproduct_solver
+  xena::future<memmg::managed_array<c21t::element_p3>>
+  solve(mtxi::index_table&& multiproduct_table, basct::cspan<c21t::element_p3> generators,
+        const basct::blob_array& masks, size_t num_inputs) const noexcept override;
+};
+} // namespace sxt::mtxc21

--- a/sxt/multiexp/curve21/pippenger_multiproduct_solver.t.cc
+++ b/sxt/multiexp/curve21/pippenger_multiproduct_solver.t.cc
@@ -1,0 +1,73 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/curve21/pippenger_multiproduct_solver.h"
+
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve21/operation/overload.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/ristretto/type/literal.h"
+
+using namespace sxt;
+using namespace sxt::mtxc21;
+using sxt::rstt::operator""_rs;
+
+TEST_CASE("we can use pippenger's algorithm to solve the multiproduct subproblem in "
+          "multiexponentiation") {
+  pippenger_multiproduct_solver solver;
+
+  SECTION("we handle the empty case") {
+    mtxi::index_table products;
+    auto res = solver.solve(std::move(products), {}, {}, 0).value();
+    memmg::managed_array<c21t::element_p3> expected;
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle non-empty products") {
+    mtxi::index_table products{{0, 0, 0}, {1, 0, 1, 2}};
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+        0x345_rs,
+        0x567_rs,
+    };
+    basct::blob_array mask(3, 1);
+    mask[0][0] = 1;
+    mask[1][0] = 1;
+    mask[2][0] = 1;
+    auto res = solver.solve(std::move(products), generators, mask, 3).value();
+    REQUIRE(res[0] == generators[0]);
+    REQUIRE(res[1] == generators[1] + generators[2]);
+  }
+
+  SECTION("we handle generators that aren't used") {
+    mtxi::index_table products{{0, 0, 0}, {1, 0, 0, 1}};
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+        0x345_rs,
+        0x567_rs,
+    };
+    basct::blob_array mask(3, 1);
+    mask[0][0] = 1;
+    mask[1][0] = 0;
+    mask[2][0] = 1;
+    auto res = solver.solve(std::move(products), generators, mask, 2).value();
+    REQUIRE(res[0] == generators[0]);
+    REQUIRE(res[1] == generators[0] + generators[2]);
+  }
+}

--- a/sxt/multiexp/doc/info.md
+++ b/sxt/multiexp/doc/info.md
@@ -1,0 +1,97 @@
+# multiexp [mtx]
+
+## base [mtxb]
+### digit_utility
+### exponent_sequence_utility
+### exponent_sequence
+### generator_utility
+
+## bitset_multiprod [mtxbmp]
+### multiproduct
+### test_operator
+### value_cache_utility
+### value_cache
+
+## curve [mtxcrv]
+The components inside the curve package are a generic implementation of multi-scalar multiplication/exponentiation that can be used on different curves.
+### doubling_reduction
+### multiexponentiation_cpu_driver
+### multiproduct_bitset_operator
+### multiproduct_solver
+Base class where all the solvers inherit their interfaces from.
+### multiproducts_combination
+### naive_multiproduct_solver
+Used for testing in the `multiexponentition_cpu_driver` component.
+
+## curve21 [mtxc21]
+The components inside the curve21 package are an implementation of multi-scalar multiplication/exponentiation that can be used on `curve25519`.
+### multiexponentiation
+### multiproduct_cpu_driver
+### multiproduct_solver
+### multiproduct
+### pippenger_multiproduct_solver
+
+## index
+### clump2_descriptor_utility
+### clump2_descriptor
+### clump2_marker_utility
+### index_table_utility
+### index_table
+### marker_transformation
+### partition_marker_utility
+### random_clump2
+### reindex
+### transpose
+
+## multiproduct_gpu
+### block_computation_descriptor
+### completion
+### computation_setup
+### kernel
+### multiproduct_computation_description
+### multiproduct
+
+## pippenger
+### driver
+### exponent_aggregates_computation
+### exponent_aggregates
+### multiexponentiation
+### multiproduct_decomposition_gpu
+### multiproduct_decomposition_kernel
+### multiproduct_table
+### test_driver
+
+## pippenger_multiprod
+### active_count
+### active_offset
+### clump_inputs
+### clump_outputs
+### driver
+### multiproduct_params_computation
+### multiproduct_params
+### multiproduct
+### partition_inputs
+### product_table_normalization
+### prune
+### reduction_stats
+### test_driver
+
+## random [mtxrn]
+The components inside the random package help generate random inputs, exponents, and products for testing multi-scalar multiplication/exponentiation.
+### int_generation
+Generates a span of uniformily distributed `uint64` values.
+### random_multiexponentiation_descriptor
+Description of exponent parameters used by the `random_multiexponentiation_generation` component.
+### random_multiexponentiation_generation
+Generates random inputs and exponents used to test multiexponentiation algorithm.
+### random_multiproduct_descriptor
+Description of product parameters used by `random_multiproduct_generation` component.
+### random_multiproduct_generation
+Generates a random index table of products used to test multiproduct algorithm.
+
+## test [mtxtst]
+The components inside the test package help with testing multi-scalar multiplication/exponentiation.
+### add_ints
+### compute_uint64_muladd
+### curve21_arithmetic
+### multiexponentiation

--- a/sxt/multiexp/index/BUILD
+++ b/sxt/multiexp/index/BUILD
@@ -1,0 +1,126 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "clump2_descriptor",
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "clump2_descriptor_utility",
+    impl_deps = [
+        ":clump2_descriptor",
+    ],
+    test_deps = [
+        ":clump2_descriptor",
+        "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
+    name = "clump2_marker_utility",
+    impl_deps = [
+        ":clump2_descriptor",
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        ":clump2_descriptor",
+        ":clump2_descriptor_utility",
+        ":random_clump2",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "marker_transformation",
+    test_deps = [
+        ":index_table",
+        ":partition_marker_utility",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "partition_marker_utility",
+    impl_deps = [
+        "//sxt/base/bit:count",
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "index_table",
+    test_deps = [
+        "//sxt/base/test:allocator_aware",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/memory:alloc",
+    ],
+)
+
+sxt_cc_component(
+    name = "index_table_utility",
+    impl_deps = [
+        ":index_table",
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "random_clump2",
+    with_test = False,
+    deps = [
+        ":clump2_descriptor",
+    ],
+)
+
+sxt_cc_component(
+    name = "reindex",
+    test_deps = [
+        ":index_table",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/functional:function_ref",
+    ],
+)
+
+sxt_cc_component(
+    name = "transpose",
+    impl_deps = [
+        ":index_table",
+        ":index_table_utility",
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        ":index_table",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/functional:function_ref",
+    ],
+)

--- a/sxt/multiexp/index/clump2_descriptor.cc
+++ b/sxt/multiexp/index/clump2_descriptor.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/clump2_descriptor.h"

--- a/sxt/multiexp/index/clump2_descriptor.h
+++ b/sxt/multiexp/index/clump2_descriptor.h
@@ -1,0 +1,30 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// clump2_descriptor
+//--------------------------------------------------------------------------------------------------
+struct clump2_descriptor {
+  uint64_t size;
+  uint64_t subset_count; // the number of subsets of {1, .., size} of
+                         // at most cardinality 2
+};
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/clump2_descriptor_utility.cc
+++ b/sxt/multiexp/index/clump2_descriptor_utility.cc
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/clump2_descriptor_utility.h"
+
+#include "sxt/multiexp/index/clump2_descriptor.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// init_clump2_descriptor
+//--------------------------------------------------------------------------------------------------
+void init_clump2_descriptor(clump2_descriptor& descriptor, uint64_t clump_size) noexcept {
+  descriptor.size = clump_size;
+  descriptor.subset_count = clump_size * (clump_size - 1) / 2 + clump_size;
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/clump2_descriptor_utility.h
+++ b/sxt/multiexp/index/clump2_descriptor_utility.h
@@ -1,0 +1,28 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace sxt::mtxi {
+struct clump2_descriptor;
+
+//--------------------------------------------------------------------------------------------------
+// init_clump2_descriptor
+//--------------------------------------------------------------------------------------------------
+void init_clump2_descriptor(clump2_descriptor& descriptor, uint64_t clump_size) noexcept;
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/clump2_descriptor_utility.t.cc
+++ b/sxt/multiexp/index/clump2_descriptor_utility.t.cc
@@ -1,0 +1,37 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/clump2_descriptor_utility.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/clump2_descriptor.h"
+
+using namespace sxt::mtxi;
+
+TEST_CASE("we can initialize clump2_descriptor") {
+  clump2_descriptor descriptor;
+
+  SECTION("we correctly count the number of clump2 subsets") {
+    init_clump2_descriptor(descriptor, 2);
+    REQUIRE(descriptor.subset_count == 3);
+
+    init_clump2_descriptor(descriptor, 3);
+    REQUIRE(descriptor.subset_count == 6);
+
+    init_clump2_descriptor(descriptor, 4);
+    REQUIRE(descriptor.subset_count == 10);
+  }
+}

--- a/sxt/multiexp/index/clump2_marker_utility.cc
+++ b/sxt/multiexp/index/clump2_marker_utility.cc
@@ -1,0 +1,84 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/clump2_marker_utility.h"
+
+#include <cmath>
+
+#include "sxt/base/error/assert.h"
+#include "sxt/multiexp/index/clump2_descriptor.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// compute_clump2_marker
+//--------------------------------------------------------------------------------------------------
+uint64_t compute_clump2_marker(const clump2_descriptor& descriptor, uint64_t clump_index,
+                               uint64_t index1, uint64_t index2) noexcept {
+  SXT_DEBUG_ASSERT(index1 <= index2);
+  auto part1 = clump_index * descriptor.subset_count;
+  auto part2 = descriptor.size * index1 - index1 * (index1 - 1) / 2 + (index2 - index1);
+  return part1 + part2;
+}
+
+uint64_t compute_clump2_marker(const clump2_descriptor& descriptor, uint64_t clump_index,
+                               uint64_t index) noexcept {
+  return compute_clump2_marker(descriptor, clump_index, index, index);
+}
+
+//--------------------------------------------------------------------------------------------------
+// unpack_clump2_marker
+//--------------------------------------------------------------------------------------------------
+void unpack_clump2_marker(uint64_t& clump_index, uint64_t& index1, uint64_t& index2,
+                          const clump2_descriptor& descriptor, uint64_t marker) noexcept {
+  clump_index = marker / descriptor.subset_count;
+  marker -= clump_index * descriptor.subset_count;
+
+  // apply quadratic formula
+  //
+  // Note: we make use of the property from IEEE 754 that sqrt is "correctly rounded".
+  // See https://stackoverflow.com/a/48791460/4447365
+  auto b2 = 2 * descriptor.size + 1;
+  auto x = std::sqrt(4 * descriptor.size * descriptor.size + 4 * descriptor.size + 1 - 8 * marker);
+  index1 = static_cast<uint64_t>(b2 - x) / 2;
+  auto u = descriptor.size * index1 - index1 * (index1 - 1) / 2;
+  index2 = marker - u + index1;
+}
+
+//--------------------------------------------------------------------------------------------------
+// consume_clump2_marker
+//--------------------------------------------------------------------------------------------------
+uint64_t consume_clump2_marker(basct::span<uint64_t>& indexes,
+                               const clump2_descriptor& descriptor) noexcept {
+  SXT_DEBUG_ASSERT(!indexes.empty());
+  auto idx = indexes[0];
+  auto clump_index = idx / descriptor.size;
+  auto clump_first = clump_index * descriptor.size;
+  auto index1 = idx - clump_first;
+  auto index2 = descriptor.size;
+  if (indexes.size() > 1) {
+    SXT_DEBUG_ASSERT(indexes[1] > idx);
+    index2 = indexes[1] - clump_first;
+  }
+  if (index2 >= descriptor.size) {
+    indexes = {indexes.data() + 1, indexes.size() - 1};
+    return compute_clump2_marker(descriptor, clump_index, index1, index1);
+  }
+  indexes = {indexes.data() + 2, indexes.size() - 2};
+  return compute_clump2_marker(descriptor, clump_index, index1, index2);
+
+  return 0;
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/clump2_marker_utility.h
+++ b/sxt/multiexp/index/clump2_marker_utility.h
@@ -1,0 +1,46 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxi {
+struct clump2_descriptor;
+
+//--------------------------------------------------------------------------------------------------
+// compute_clump2_marker
+//--------------------------------------------------------------------------------------------------
+uint64_t compute_clump2_marker(const clump2_descriptor& descriptor, uint64_t clump_index,
+                               uint64_t index1, uint64_t index2) noexcept;
+
+uint64_t compute_clump2_marker(const clump2_descriptor& descriptor, uint64_t clump_index,
+                               uint64_t index) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// unpack_clump2_marker
+//--------------------------------------------------------------------------------------------------
+void unpack_clump2_marker(uint64_t& clump_index, uint64_t& index1, uint64_t& index2,
+                          const clump2_descriptor& descriptor, uint64_t marker) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// consume_clump2_marker
+//--------------------------------------------------------------------------------------------------
+uint64_t consume_clump2_marker(basct::span<uint64_t>& indexes,
+                               const clump2_descriptor& descriptor) noexcept;
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/clump2_marker_utility.t.cc
+++ b/sxt/multiexp/index/clump2_marker_utility.t.cc
@@ -1,0 +1,170 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/clump2_marker_utility.h"
+
+#include <iostream>
+#include <random>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/clump2_descriptor.h"
+#include "sxt/multiexp/index/clump2_descriptor_utility.h"
+#include "sxt/multiexp/index/random_clump2.h"
+
+using namespace sxt;
+using namespace sxt::mtxi;
+
+TEST_CASE("we can convert between a clumped index set and its marker") {
+  clump2_descriptor descriptor;
+
+  uint64_t marker, clump_index, index1, index2;
+
+  SECTION("verify conversions for a clump size of 2") {
+    init_clump2_descriptor(descriptor, 2);
+
+    marker = compute_clump2_marker(descriptor, 0, 0, 0);
+    REQUIRE(marker == 0);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 0);
+    REQUIRE(index2 == 0);
+
+    marker = compute_clump2_marker(descriptor, 0, 0, 1);
+    REQUIRE(marker == 1);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 0);
+    REQUIRE(index2 == 1);
+
+    marker = compute_clump2_marker(descriptor, 0, 1, 1);
+    REQUIRE(marker == 2);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 1);
+    REQUIRE(index2 == 1);
+
+    marker = compute_clump2_marker(descriptor, 10, 1, 1);
+    REQUIRE(marker == 10 * 3 + 2);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 10);
+    REQUIRE(index1 == 1);
+    REQUIRE(index2 == 1);
+  }
+
+  SECTION("verify conversions for a clump size of 3") {
+    init_clump2_descriptor(descriptor, 3);
+
+    marker = compute_clump2_marker(descriptor, 0, 0, 0);
+    REQUIRE(marker == 0);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 0);
+    REQUIRE(index2 == 0);
+
+    marker = compute_clump2_marker(descriptor, 0, 0, 1);
+    REQUIRE(marker == 1);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 0);
+    REQUIRE(index2 == 1);
+
+    marker = compute_clump2_marker(descriptor, 0, 0, 2);
+    REQUIRE(marker == 2);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 0);
+    REQUIRE(index2 == 2);
+
+    marker = compute_clump2_marker(descriptor, 0, 1, 1);
+    REQUIRE(marker == 3);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 1);
+    REQUIRE(index2 == 1);
+
+    marker = compute_clump2_marker(descriptor, 0, 1, 2);
+    REQUIRE(marker == 4);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 1);
+    REQUIRE(index2 == 2);
+
+    marker = compute_clump2_marker(descriptor, 0, 2, 2);
+    REQUIRE(marker == 5);
+    unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    REQUIRE(clump_index == 0);
+    REQUIRE(index1 == 2);
+    REQUIRE(index2 == 2);
+  }
+
+  SECTION("verify we can recover indexes from the marker of a random clump") {
+    std::mt19937 rng{0};
+    for (int i = 0; i < 10; ++i) {
+      random_clump2 clump;
+      generate_random_clump2(clump, rng);
+      init_clump2_descriptor(descriptor, clump.clump_size);
+
+      // 1 subset case
+      marker = compute_clump2_marker(descriptor, clump.clump_index, clump.index1, clump.index1);
+      unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+      REQUIRE(clump_index == clump.clump_index);
+      REQUIRE(index1 == clump.index1);
+      REQUIRE(index2 == clump.index1);
+
+      // 2 subset case
+      marker = compute_clump2_marker(descriptor, clump.clump_index, clump.index1, clump.index2);
+      unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+      REQUIRE(clump_index == clump.clump_index);
+      REQUIRE(index1 == clump.index1);
+      REQUIRE(index2 == clump.index2);
+    }
+  }
+}
+
+TEST_CASE("we can consume clump2 markers from a span of indexes") {
+  const uint64_t clump_size = 15;
+  basct::span<uint64_t> values;
+  uint64_t marker;
+  clump2_descriptor descriptor;
+  init_clump2_descriptor(descriptor, clump_size);
+
+  SECTION("we can consume a single marker") {
+    uint64_t data[1] = {0};
+    values = data;
+
+    marker = consume_clump2_marker(values, descriptor);
+    REQUIRE(marker == 0);
+    REQUIRE(values.empty());
+  }
+
+  SECTION("we can consume 2 values belonging to the same clump") {
+    uint64_t data[2] = {0, clump_size - 1};
+    values = data;
+    marker = consume_clump2_marker(values, descriptor);
+    REQUIRE(marker == compute_clump2_marker(descriptor, 0, data[0], data[1]));
+    REQUIRE(values.empty());
+  }
+
+  SECTION("we only consume a single value if the next value belongs to a different "
+          "clump") {
+    uint64_t data[2] = {0, clump_size};
+    values = data;
+    marker = consume_clump2_marker(values, descriptor);
+    REQUIRE(marker == compute_clump2_marker(descriptor, 0, data[0], data[0]));
+    REQUIRE(values.size() == 1);
+    REQUIRE(&values[0] == &data[1]);
+  }
+}

--- a/sxt/multiexp/index/index_table.cc
+++ b/sxt/multiexp/index/index_table.cc
@@ -1,0 +1,201 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/index_table.h"
+
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <utility>
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+index_table::index_table(const index_table& other) noexcept
+    : index_table{other, other.get_allocator()} {}
+
+index_table::index_table(const index_table& other, allocator_type alloc) noexcept : alloc_{alloc} {
+  this->operator=(other);
+}
+
+index_table::index_table(index_table&& other) noexcept
+    : index_table{std::move(other), other.get_allocator()} {}
+
+index_table::index_table(index_table&& other, allocator_type alloc) noexcept : alloc_{alloc} {
+  this->operator=(std::move(other));
+}
+
+index_table::index_table(size_t num_rows, size_t max_entries, allocator_type alloc) noexcept
+    : alloc_{alloc} {
+  this->reshape(num_rows, max_entries);
+}
+
+index_table::index_table(std::initializer_list<std::initializer_list<uint64_t>> values,
+                         allocator_type alloc) noexcept
+    : alloc_{alloc} {
+  auto num_rows = values.size();
+  size_t entry_count = 0;
+  for (auto row : values) {
+    entry_count += row.size();
+  }
+  this->reshape(num_rows, entry_count);
+
+  auto hdr = this->header();
+  auto rows_p = values.begin();
+  auto entry_data = reinterpret_cast<uint64_t*>(data_ + sizeof(header_type) * num_rows_);
+  for (size_t index = 0; index < num_rows; ++index) {
+    auto& row = hdr[index];
+    auto row_p = *(rows_p + index);
+    row = header_type{entry_data, row_p.size()};
+    entry_data = std::copy(row_p.begin(), row_p.end(), entry_data);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// destructor
+//--------------------------------------------------------------------------------------------------
+index_table::~index_table() noexcept { this->reset(); }
+
+//--------------------------------------------------------------------------------------------------
+// operator=
+//--------------------------------------------------------------------------------------------------
+index_table& index_table::operator=(const index_table& rhs) noexcept {
+  if (this == &rhs) {
+    return *this;
+  }
+  if (capacity_ < rhs.capacity_) {
+    this->reset();
+    capacity_ = rhs.capacity_;
+    data_ = alloc_.allocate(capacity_);
+  }
+  num_rows_ = rhs.num_rows_;
+  auto hdr = this->header();
+  auto hdr_p = rhs.header();
+
+  auto entry_data = this->entry_data();
+  for (size_t index = 0; index < num_rows_; ++index) {
+    auto& row = hdr[index];
+    auto row_p = hdr_p[index];
+    row = header_type{entry_data, row_p.size()};
+    entry_data = std::copy(row_p.begin(), row_p.end(), entry_data);
+  }
+
+  return *this;
+}
+
+index_table& index_table::operator=(index_table&& rhs) noexcept {
+  if (this->get_allocator() != rhs.get_allocator()) {
+    return this->operator=(rhs);
+  }
+
+  this->reset();
+
+  num_rows_ = rhs.num_rows_;
+  capacity_ = rhs.capacity_;
+  data_ = rhs.data_;
+
+  rhs.num_rows_ = 0;
+  rhs.capacity_ = 0;
+  rhs.data_ = nullptr;
+
+  return *this;
+}
+
+//--------------------------------------------------------------------------------------------------
+// entry_data
+//--------------------------------------------------------------------------------------------------
+uint64_t* index_table::entry_data() noexcept {
+  return reinterpret_cast<uint64_t*>(data_ + sizeof(header_type) * num_rows_);
+}
+
+const uint64_t* index_table::entry_data() const noexcept {
+  return reinterpret_cast<const uint64_t*>(data_ + sizeof(header_type) * num_rows_);
+}
+
+//--------------------------------------------------------------------------------------------------
+// reset
+//--------------------------------------------------------------------------------------------------
+void index_table::reset() noexcept {
+  if (data_ == nullptr) {
+    return;
+  }
+  alloc_.deallocate(data_, capacity_);
+  num_rows_ = 0;
+  data_ = nullptr;
+  capacity_ = 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+// reshape
+//--------------------------------------------------------------------------------------------------
+void index_table::reshape(size_t num_rows, size_t max_entries) noexcept {
+  auto capacity_p = num_rows * sizeof(basct::span<uint64_t>) + max_entries * sizeof(uint64_t);
+  if (capacity_p <= capacity_) {
+    num_rows_ = num_rows;
+    return;
+  }
+  this->reset();
+  num_rows_ = num_rows;
+  capacity_ = capacity_p;
+  data_ = alloc_.allocate(capacity_p);
+}
+
+//--------------------------------------------------------------------------------------------------
+// operator==
+//--------------------------------------------------------------------------------------------------
+bool operator==(const index_table& lhs, const index_table& rhs) noexcept {
+  auto hdr = lhs.header();
+  auto hdr_p = rhs.header();
+  if (hdr.size() != hdr_p.size()) {
+    return false;
+  }
+  for (size_t index = 0; index < hdr.size(); ++index) {
+    auto row = hdr[index];
+    auto row_p = hdr_p[index];
+    if (row.size() != row_p.size()) {
+      return false;
+    }
+    if (!std::equal(row.begin(), row.end(), row_p.begin())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+// operator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const index_table& tbl) {
+  auto hdr = tbl.header();
+  out << "{";
+  for (auto& row : hdr) {
+    out << "{";
+    for (auto& entry : row) {
+      out << entry;
+      if (std::distance(&entry, row.end()) > 1) {
+        out << ",";
+      }
+    }
+    out << "}";
+    if (std::distance(&row, hdr.end()) > 1) {
+      out << ",";
+    }
+  }
+  out << "}";
+  return out;
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/index_table.h
+++ b/sxt/multiexp/index/index_table.h
@@ -1,0 +1,111 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <initializer_list>
+#include <iosfwd>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/memory/alloc.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// index_table
+//--------------------------------------------------------------------------------------------------
+class index_table {
+public:
+  using allocator_type = basm::alloc_t;
+  using header_type = basct::span<uint64_t>;
+  using const_header_type = basct::span<const uint64_t>;
+
+  // constructors
+  index_table() noexcept = default;
+
+  explicit index_table(allocator_type alloc) noexcept : alloc_{alloc} {}
+
+  index_table(const index_table& other) noexcept;
+
+  index_table(const index_table& other, allocator_type alloc) noexcept;
+
+  index_table(index_table&& other) noexcept;
+
+  index_table(index_table&& other, allocator_type alloc) noexcept;
+
+  index_table(size_t num_rows, size_t max_entries, allocator_type alloc = {}) noexcept;
+
+  index_table(std::initializer_list<std::initializer_list<uint64_t>> values,
+              allocator_type alloc = {}) noexcept;
+
+  // destructor
+  ~index_table() noexcept;
+
+  // assignment
+  index_table& operator=(const index_table& rhs) noexcept;
+
+  index_table& operator=(index_table&& rhs) noexcept;
+
+  // accessors
+  allocator_type get_allocator() const noexcept { return alloc_; }
+
+  uint64_t* entry_data() noexcept;
+  const uint64_t* entry_data() const noexcept;
+
+  size_t num_rows() const noexcept { return num_rows_; }
+
+  // methods
+  bool empty() const noexcept { return num_rows_ == 0; }
+
+  void reset() noexcept;
+
+  basct::span<header_type> header() noexcept {
+    return basct::span<header_type>{reinterpret_cast<header_type*>(data_), num_rows_};
+  }
+
+  basct::span<const const_header_type> header() const noexcept {
+    return basct::span<const const_header_type>{reinterpret_cast<const_header_type*>(data_),
+                                                num_rows_};
+  }
+
+  basct::span<const const_header_type> cheader() const noexcept { return this->header(); }
+
+  void reshape(size_t num_rows, size_t max_entries) noexcept;
+
+private:
+  allocator_type alloc_;
+  size_t num_rows_{0};
+  size_t capacity_{0};
+  std::byte* data_ = nullptr;
+};
+
+//--------------------------------------------------------------------------------------------------
+// operator==
+//--------------------------------------------------------------------------------------------------
+bool operator==(const index_table& lhs, const index_table& rhs) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// operator!=
+//--------------------------------------------------------------------------------------------------
+inline bool operator!=(const index_table& lhs, const index_table& rhs) noexcept {
+  return !(lhs == rhs);
+}
+
+//--------------------------------------------------------------------------------------------------
+// operator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const index_table& tbl);
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/index_table.t.cc
+++ b/sxt/multiexp/index/index_table.t.cc
@@ -1,0 +1,72 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/index_table.h"
+
+#include <sstream>
+
+#include "sxt/base/test/allocator_aware.h"
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::mtxi;
+
+TEST_CASE("index_table manages a table of 64-bit index values") {
+  SECTION("we can construct a table from an initializer list") {
+    index_table tbl{{1, 2}, {3, 4, 5}};
+    auto hdr = tbl.header();
+
+    REQUIRE(hdr.size() == 2);
+
+    REQUIRE(hdr[0].size() == 2);
+    REQUIRE(hdr[0][0] == 1);
+    REQUIRE(hdr[0][1] == 2);
+
+    REQUIRE(hdr[1].size() == 3);
+    REQUIRE(hdr[1][0] == 3);
+    REQUIRE(hdr[1][1] == 4);
+    REQUIRE(hdr[1][2] == 5);
+  }
+
+  SECTION("we can compare index tables") {
+    index_table tbl1{{1}, {7, 9, 13}, {5, 2}};
+    index_table tbl2{{1}, {7, 9, 13}, {5, 11}};
+    index_table tbl3;
+    REQUIRE(tbl1 == tbl1);
+    REQUIRE(tbl1 != tbl2);
+    REQUIRE(tbl1 != tbl3);
+  }
+
+  SECTION("we can print a table") {
+    index_table tbl{};
+    std::ostringstream oss;
+
+    oss << tbl;
+    REQUIRE(oss.str() == "{}");
+    oss.clear();
+
+    oss = std::ostringstream{};
+    tbl = {{1}, {2, 3}};
+    oss << tbl;
+    REQUIRE(oss.str() == "{{1},{2,3}}");
+    oss.clear();
+  }
+
+  SECTION("verify allocator-aware operations") {
+    index_table tbl{{1}, {2, 3}, {4}};
+    bastst::exercise_allocator_aware_operations(tbl);
+  }
+}

--- a/sxt/multiexp/index/index_table_utility.cc
+++ b/sxt/multiexp/index/index_table_utility.cc
@@ -1,0 +1,35 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/index_table_utility.h"
+
+#include "sxt/base/error/assert.h"
+#include "sxt/multiexp/index/index_table.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// init_rows
+//--------------------------------------------------------------------------------------------------
+void init_rows(index_table& table, basct::cspan<size_t> sizes) noexcept {
+  SXT_DEBUG_ASSERT(table.num_rows() == sizes.size());
+  auto entry_data = table.entry_data();
+  auto rows = table.header();
+  for (size_t row_index = 0; row_index < sizes.size(); ++row_index) {
+    rows[row_index] = {entry_data, 0};
+    entry_data += sizes[row_index];
+  }
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/index_table_utility.h
+++ b/sxt/multiexp/index/index_table_utility.h
@@ -1,0 +1,30 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxi {
+class index_table;
+
+//--------------------------------------------------------------------------------------------------
+// init_rows
+//--------------------------------------------------------------------------------------------------
+void init_rows(index_table& table, basct::cspan<size_t> sizes) noexcept;
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/index_table_utility.t.cc
+++ b/sxt/multiexp/index/index_table_utility.t.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/index_table_utility.h"

--- a/sxt/multiexp/index/marker_transformation.cc
+++ b/sxt/multiexp/index/marker_transformation.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/marker_transformation.h"

--- a/sxt/multiexp/index/marker_transformation.h
+++ b/sxt/multiexp/index/marker_transformation.h
@@ -1,0 +1,62 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// apply_marker_row_transformation
+//--------------------------------------------------------------------------------------------------
+template <class F>
+void apply_marker_row_transformation(basct::span<uint64_t>& indexes, F consumer,
+                                     size_t offset) noexcept {
+  auto out = indexes.begin() + offset;
+  auto rest = indexes.subspan(offset);
+  while (!rest.empty()) {
+    *out++ = consumer(rest);
+  }
+  indexes = basct::span<uint64_t>{indexes.data(),
+                                  static_cast<size_t>(std::distance(indexes.begin(), out))};
+}
+
+//--------------------------------------------------------------------------------------------------
+// apply_marker_transformation
+//--------------------------------------------------------------------------------------------------
+template <class F, class OffsetFunctor>
+size_t apply_marker_transformation(basct::span<basct::span<uint64_t>> rows, F consumer,
+                                   OffsetFunctor offset_functor) noexcept {
+  size_t count = 0;
+  for (auto& row : rows) {
+    auto offset = offset_functor(row);
+    apply_marker_row_transformation(row, consumer, offset);
+    count += row.size() - offset;
+  }
+  return count;
+}
+
+template <class F>
+size_t apply_marker_transformation(basct::span<basct::span<uint64_t>> rows, F consumer) noexcept {
+  return apply_marker_transformation(rows, consumer,
+                                     [](basct::cspan<uint64_t> /*row*/) noexcept { return 0; });
+}
+
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/marker_transformation.t.cc
+++ b/sxt/multiexp/index/marker_transformation.t.cc
@@ -1,0 +1,65 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/marker_transformation.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/index/partition_marker_utility.h"
+
+using namespace sxt;
+using namespace sxt::mtxi;
+
+TEST_CASE("we can transform an index table into partition markers") {
+  auto consumer = [](basct::span<uint64_t>& indexes) noexcept {
+    return consume_partition_marker(indexes, 2);
+  };
+
+  SECTION("we properly handle the empty table") {
+    index_table tbl;
+    REQUIRE(apply_marker_transformation(tbl.header(), consumer) == 0);
+    REQUIRE(tbl.empty());
+  }
+
+  SECTION("we correctly handle a table with a single entry") {
+    index_table tbl{{10}};
+    REQUIRE(apply_marker_transformation(tbl.header(), consumer) == 1);
+    index_table expected_tbl{{21}};
+    REQUIRE(tbl == expected_tbl);
+  }
+
+  SECTION("we handle the case where a row shrinks in size") {
+    index_table tbl{{2, 3, 4}};
+    REQUIRE(apply_marker_transformation(tbl.header(), consumer) == 2);
+    index_table expected_tbl{{7, 9}};
+    REQUIRE(tbl == expected_tbl);
+  }
+
+  SECTION("we correctly handle multiple rows") {
+    index_table tbl{{2, 3, 4}, {10}};
+    REQUIRE(apply_marker_transformation(tbl.header(), consumer) == 3);
+    index_table expected_tbl{{7, 9}, {21}};
+    REQUIRE(tbl == expected_tbl);
+  }
+
+  SECTION("we can use an offset functor to skip over entries") {
+    index_table tbl{{2, 3, 4}, {10}};
+    auto offset_functor = [](basct::cspan<uint64_t> row) noexcept { return 1; };
+    REQUIRE(apply_marker_transformation(tbl.header(), consumer, offset_functor) == 2);
+    index_table expected_tbl{{2, 6, 9}, {10}};
+    REQUIRE(tbl == expected_tbl);
+  }
+}

--- a/sxt/multiexp/index/partition_marker_utility.cc
+++ b/sxt/multiexp/index/partition_marker_utility.cc
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/partition_marker_utility.h"
+
+#include "sxt/base/bit/count.h"
+#include "sxt/base/error/assert.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// consume_partition_marker
+//--------------------------------------------------------------------------------------------------
+uint64_t consume_partition_marker(basct::span<uint64_t>& indexes,
+                                  uint64_t partition_size) noexcept {
+  SXT_DEBUG_ASSERT(!indexes.empty());
+  SXT_DEBUG_ASSERT(partition_size > 0 && partition_size < 64);
+  auto n = indexes.size();
+  auto idx = indexes[0];
+  auto partition_index = idx / partition_size;
+  auto partition_first = partition_index * partition_size;
+  auto partition_offset = idx - partition_index * partition_size;
+  uint64_t marker = (partition_index << partition_size) | (1 << partition_offset);
+  size_t i = 1;
+  for (; i < n; ++i) {
+    SXT_DEBUG_ASSERT(idx < indexes[i]);
+    idx = indexes[i];
+    partition_offset = idx - partition_first;
+    if (partition_offset >= partition_size) {
+      break;
+    }
+    marker |= (1 << partition_offset);
+  }
+  indexes = basct::span{indexes.data() + i, n - i};
+  return marker;
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/partition_marker_utility.h
+++ b/sxt/multiexp/index/partition_marker_utility.h
@@ -1,0 +1,28 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// consume_partition_marker
+//--------------------------------------------------------------------------------------------------
+uint64_t consume_partition_marker(basct::span<uint64_t>& indexes, uint64_t partition_size) noexcept;
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/partition_marker_utility.t.cc
+++ b/sxt/multiexp/index/partition_marker_utility.t.cc
@@ -1,0 +1,88 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/partition_marker_utility.h"
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::mtxi;
+
+TEST_CASE("we can condense a sequences of indexes down to a marker of its partition "
+          "set") {
+  SECTION("we correctly handle cases with a single element") {
+    uint64_t data[1];
+
+    basct::span<uint64_t> values;
+    uint64_t marker;
+
+    *data = 0;
+    values = data;
+    marker = consume_partition_marker(values, 1);
+    REQUIRE(values.empty());
+    REQUIRE(marker == 1);
+
+    *data = 1;
+    values = data;
+    marker = consume_partition_marker(values, 1);
+    REQUIRE(values.empty());
+    REQUIRE(marker == 3);
+
+    *data = 5;
+    values = data;
+    marker = consume_partition_marker(values, 10);
+    REQUIRE(values.empty());
+    REQUIRE(marker == 32);
+  }
+
+  SECTION("we correctly handle cases with two elements with two elements") {
+    uint64_t data[2];
+
+    basct::span<uint64_t> values;
+    uint64_t marker;
+
+    data[0] = 0;
+    data[1] = 1;
+    values = data;
+    marker = consume_partition_marker(values, 1);
+    REQUIRE(values.size() == 1);
+    REQUIRE(values[0] == 1);
+    REQUIRE(marker == 1);
+
+    data[0] = 0;
+    data[1] = 1;
+    values = data;
+    marker = consume_partition_marker(values, 2);
+    REQUIRE(values.empty());
+    REQUIRE(marker == 3);
+
+    data[0] = 1;
+    data[1] = 2;
+    values = data;
+    marker = consume_partition_marker(values, 2);
+    REQUIRE(values.size() == 1);
+    REQUIRE(values[0] == 2);
+    REQUIRE(marker == 2);
+
+    data[0] = 3;
+    data[1] = 5;
+    values = data;
+    marker = consume_partition_marker(values, 2);
+    REQUIRE(values.size() == 1);
+    REQUIRE(values[0] == 5);
+    REQUIRE(marker == 6);
+  }
+}

--- a/sxt/multiexp/index/random_clump2.cc
+++ b/sxt/multiexp/index/random_clump2.cc
@@ -1,0 +1,41 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/random_clump2.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// generate_random_clump2
+//--------------------------------------------------------------------------------------------------
+void generate_random_clump2(random_clump2& clump, std::mt19937& rng) noexcept {
+  constexpr uint64_t max_clump_size = 10'000;
+  constexpr uint64_t max_clump_index = 1'000;
+
+  std::uniform_int_distribution<uint64_t> clump_size_dist{0, max_clump_size};
+  std::uniform_int_distribution<uint64_t> clump_index_dist{0, max_clump_index};
+
+  auto clump_size = clump_size_dist(rng);
+  clump.clump_size = clump_size;
+  clump.clump_index = clump_index_dist(rng);
+
+  std::uniform_int_distribution<uint64_t> index1_dist{0, clump_size - 1};
+  auto index1 = index1_dist(rng);
+  clump.index1 = index1;
+
+  std::uniform_int_distribution<uint64_t> index2_dist{index1, clump_size - 1};
+  clump.index2 = index2_dist(rng);
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/random_clump2.h
+++ b/sxt/multiexp/index/random_clump2.h
@@ -1,0 +1,39 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <random>
+
+#include "sxt/multiexp/index/clump2_descriptor.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// random_clump2
+//--------------------------------------------------------------------------------------------------
+struct random_clump2 {
+  uint64_t clump_size;
+  uint64_t clump_index;
+  uint64_t index1;
+  uint64_t index2;
+};
+
+//--------------------------------------------------------------------------------------------------
+// generate_random_clump2
+//--------------------------------------------------------------------------------------------------
+void generate_random_clump2(random_clump2& clump, std::mt19937& rng) noexcept;
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/reindex.cc
+++ b/sxt/multiexp/index/reindex.cc
@@ -1,0 +1,126 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/reindex.h"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// heap_element
+//--------------------------------------------------------------------------------------------------
+namespace {
+using heap_element = std::pair<uint64_t*, uint64_t>;
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+// comp
+//--------------------------------------------------------------------------------------------------
+namespace {
+struct comp {
+  bool operator()(heap_element lhs, heap_element rhs) const noexcept {
+    return *lhs.first > *rhs.first;
+  }
+};
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+// init_heap
+//--------------------------------------------------------------------------------------------------
+static void init_heap(std::vector<heap_element>& heap, basct::span<basct::span<uint64_t>> rows,
+                      basf::function_ref<size_t(basct::cspan<uint64_t>)> offset_functor) noexcept {
+  heap.reserve(rows.size());
+  for (size_t row_index = 0; row_index < rows.size(); ++row_index) {
+    auto row = rows[row_index];
+    if (row.empty()) {
+      continue;
+    }
+    heap.emplace_back(row.data() + offset_functor(row), row_index);
+  }
+  std::make_heap(heap.begin(), heap.end(), comp{});
+}
+
+//--------------------------------------------------------------------------------------------------
+// advance_heap
+//--------------------------------------------------------------------------------------------------
+static void advance_heap(std::vector<heap_element>& heap,
+                         basct::span<basct::span<uint64_t>> rows) noexcept {
+  auto& [ptr, index] = heap.back();
+  ++ptr;
+  auto row = rows[index];
+  if (ptr == row.end()) {
+    heap.resize(heap.size() - 1);
+  } else {
+    std::push_heap(heap.begin(), heap.end(), comp{});
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// pop_first
+//--------------------------------------------------------------------------------------------------
+static void pop_first(uint64_t*& out, std::vector<heap_element>& heap,
+                      basct::span<basct::span<uint64_t>> rows) noexcept {
+  std::pop_heap(heap.begin(), heap.end(), comp{});
+  *out = *heap.back().first;
+  *heap.back().first = 0;
+  advance_heap(heap, rows);
+}
+
+//--------------------------------------------------------------------------------------------------
+// pop
+//--------------------------------------------------------------------------------------------------
+static void pop(uint64_t*& out, size_t& working_index, std::vector<heap_element>& heap,
+                basct::span<basct::span<uint64_t>> rows) noexcept {
+  std::pop_heap(heap.begin(), heap.end(), comp{});
+  auto& ptr = heap.back().first;
+  if (*out != *ptr) {
+    *++out = *ptr;
+    *ptr = ++working_index;
+  } else {
+    *ptr = working_index;
+  }
+  advance_heap(heap, rows);
+}
+
+//--------------------------------------------------------------------------------------------------
+// reindex_rows
+//--------------------------------------------------------------------------------------------------
+void reindex_rows(basct::span<basct::span<uint64_t>> rows, basct::span<uint64_t>& values,
+                  basf::function_ref<size_t(basct::cspan<uint64_t>)> offset_functor) noexcept {
+  if (rows.empty()) {
+    values = {};
+    return;
+  }
+  std::vector<heap_element> heap;
+  init_heap(heap, rows, offset_functor);
+
+  auto out = values.begin();
+  pop_first(out, heap, rows);
+  uint64_t working_index = 0;
+  while (!heap.empty()) {
+    pop(out, working_index, heap, rows);
+  }
+
+  values = {values.data(), working_index + 1};
+}
+
+void reindex_rows(basct::span<basct::span<uint64_t>> rows, basct::span<uint64_t>& values) noexcept {
+  auto offset_functor = [](basct::cspan<uint64_t> /*row*/) noexcept { return 0; };
+  reindex_rows(rows, values, offset_functor);
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/reindex.h
+++ b/sxt/multiexp/index/reindex.h
@@ -1,0 +1,32 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/functional/function_ref.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// reindex_rows
+//--------------------------------------------------------------------------------------------------
+void reindex_rows(basct::span<basct::span<uint64_t>> rows, basct::span<uint64_t>& values) noexcept;
+
+void reindex_rows(basct::span<basct::span<uint64_t>> rows, basct::span<uint64_t>& values,
+                  basf::function_ref<size_t(basct::cspan<uint64_t>)> offset_functor) noexcept;
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/reindex.t.cc
+++ b/sxt/multiexp/index/reindex.t.cc
@@ -1,0 +1,108 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/reindex.h"
+
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/index_table.h"
+
+using namespace sxt;
+using namespace sxt::mtxi;
+
+TEST_CASE("we can reindex a table") {
+  std::vector<uint64_t> values_data(10);
+  basct::span<uint64_t> values{values_data.data(), values_data.size()};
+
+  SECTION("reindexing an empty table does nothing") {
+    index_table tbl;
+
+    reindex_rows(tbl.header(), values);
+    REQUIRE(tbl.empty());
+    REQUIRE(values.empty());
+  }
+
+  SECTION("we can reindex a table with a single element") {
+    index_table tbl{{10}};
+
+    reindex_rows(tbl.header(), values);
+    values_data.resize(values.size());
+    index_table expected_tbl{{0}};
+    REQUIRE(tbl == expected_tbl);
+    REQUIRE(values_data == std::vector<uint64_t>{10});
+  }
+
+  SECTION("we can reindex a table with two elements") {
+    index_table tbl{{10, 15}};
+
+    reindex_rows(tbl.header(), values);
+    values_data.resize(values.size());
+    index_table expected_tbl{{0, 1}};
+    REQUIRE(tbl == expected_tbl);
+    REQUIRE(values_data == std::vector<uint64_t>{10, 15});
+  }
+
+  SECTION("we correctly handle two rows with identical values") {
+    index_table tbl{{10}, {10}};
+
+    reindex_rows(tbl.header(), values);
+    values_data.resize(values.size());
+    index_table expected_tbl{{0}, {0}};
+    REQUIRE(tbl == expected_tbl);
+    REQUIRE(values_data == std::vector<uint64_t>{10});
+  }
+
+  SECTION("we can use an offset functor to skip over entries") {
+    index_table tbl{{10, 11}, {10, 12}};
+    auto f = [](basct::cspan<uint64_t> row) noexcept { return 1; };
+    reindex_rows(tbl.header(), values, f);
+    values_data.resize(values.size());
+    index_table expected_tbl{{10, 0}, {10, 1}};
+    REQUIRE(tbl == expected_tbl);
+    REQUIRE(values_data == std::vector<uint64_t>{11, 12});
+  }
+
+  SECTION("we correctly handle two rows with two unique values") {
+    index_table tbl{{10}, {20}};
+
+    reindex_rows(tbl.header(), values);
+    values_data.resize(values.size());
+    index_table expected_tbl{{0}, {1}};
+    REQUIRE(tbl == expected_tbl);
+    REQUIRE(values_data == std::vector<uint64_t>{10, 20});
+  }
+
+  SECTION("we correctly handle two rows with three unique values") {
+    index_table tbl{{10}, {1, 20}};
+
+    reindex_rows(tbl.header(), values);
+    values_data.resize(values.size());
+    index_table expected_tbl{{1}, {0, 2}};
+    REQUIRE(tbl == expected_tbl);
+    REQUIRE(values_data == std::vector<uint64_t>{1, 10, 20});
+  }
+
+  SECTION("we correctly handle multiple rows with multiple unique values") {
+    index_table tbl{{101}, {1, 4, 20}, {3, 7}, {4, 100, 101}};
+
+    reindex_rows(tbl.header(), values);
+    values_data.resize(values.size());
+    index_table expected_tbl{{6}, {0, 2, 4}, {1, 3}, {2, 5, 6}};
+    REQUIRE(tbl == expected_tbl);
+    REQUIRE(values_data == std::vector<uint64_t>{1, 3, 4, 7, 20, 100, 101});
+  }
+}

--- a/sxt/multiexp/index/transpose.cc
+++ b/sxt/multiexp/index/transpose.cc
@@ -1,0 +1,74 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/transpose.h"
+
+#include <vector>
+
+#include "sxt/base/error/assert.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/index/index_table_utility.h"
+
+namespace sxt::mtxi {
+//--------------------------------------------------------------------------------------------------
+// transpose
+//--------------------------------------------------------------------------------------------------
+size_t transpose(index_table& table, basct::cspan<basct::cspan<uint64_t>> rows,
+                 size_t distinct_entry_count, size_t padding,
+                 basf::function_ref<size_t(basct::cspan<uint64_t>)> offset_functor) noexcept {
+  // count entries
+  std::vector<size_t> counts(distinct_entry_count, padding);
+  size_t num_entries = distinct_entry_count * padding;
+  for (auto row : rows) {
+    for (auto x : row.subspan(offset_functor(row))) {
+      SXT_DEBUG_ASSERT(x < distinct_entry_count);
+      ++counts[x];
+      ++num_entries;
+    }
+  }
+  table.reshape(distinct_entry_count, num_entries);
+
+  // reserve space
+  init_rows(table, counts);
+
+  // add padding
+  if (padding > 0) {
+    for (auto& row : table.header()) {
+      std::fill_n(row.data(), padding, 0);
+      row = {row.data(), padding};
+    }
+  }
+
+  // populate
+  for (size_t row_index = 0; row_index < rows.size(); ++row_index) {
+    auto row = rows[row_index];
+    for (auto x : row.subspan(offset_functor(row))) {
+      auto& row_t = table.header()[x];
+      auto sz = row_t.size();
+      row_t = {row_t.data(), sz + 1};
+      row_t[sz] = row_index;
+    }
+  }
+
+  return num_entries - distinct_entry_count * padding - rows.size();
+}
+
+size_t transpose(index_table& table, basct::cspan<basct::cspan<uint64_t>> rows,
+                 size_t distinct_entry_count, size_t padding) noexcept {
+  return transpose(table, rows, distinct_entry_count, padding,
+                   [](basct::cspan<uint64_t> /*row*/) noexcept { return 0; });
+}
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/transpose.h
+++ b/sxt/multiexp/index/transpose.h
@@ -1,0 +1,36 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/functional/function_ref.h"
+
+namespace sxt::mtxi {
+class index_table;
+
+//--------------------------------------------------------------------------------------------------
+// transpose
+//--------------------------------------------------------------------------------------------------
+size_t transpose(index_table& table, basct::cspan<basct::cspan<uint64_t>> rows,
+                 size_t distinct_entry_count, size_t padding,
+                 basf::function_ref<size_t(basct::cspan<uint64_t>)> offset_functor) noexcept;
+
+size_t transpose(index_table& table, basct::cspan<basct::cspan<uint64_t>> rows,
+                 size_t distinct_entry_count, size_t padding = 0) noexcept;
+} // namespace sxt::mtxi

--- a/sxt/multiexp/index/transpose.t.cc
+++ b/sxt/multiexp/index/transpose.t.cc
@@ -1,0 +1,69 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/index/transpose.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/index_table.h"
+
+using namespace sxt;
+using namespace sxt::mtxi;
+
+TEST_CASE("we can transpose an index table") {
+  index_table table_p;
+
+  SECTION("we can transpose an empty index table") {
+    index_table table{};
+    REQUIRE(transpose(table_p, table.cheader(), 0) == 0);
+    REQUIRE(table_p == index_table{});
+  }
+
+  SECTION("we can transpose an index table with a single entry") {
+    index_table table{{0}};
+    REQUIRE(transpose(table_p, table.cheader(), 1) == 0);
+    REQUIRE(table_p == index_table{{0}});
+  }
+
+  SECTION("we can transpose a table with a single row") {
+    index_table table{{0, 1, 2, 3}};
+    REQUIRE(transpose(table_p, table.cheader(), 4) == 3);
+    REQUIRE(table_p == index_table{{0}, {0}, {0}, {0}});
+  }
+
+  SECTION("we can transpose a table with two rows") {
+    index_table table{{0, 1}, {0, 2, 3}};
+    REQUIRE(transpose(table_p, table.cheader(), 4) == 3);
+    REQUIRE(table_p == index_table{{0, 1}, {0}, {1}, {1}});
+  }
+
+  SECTION("we can add padding while transposing") {
+    index_table table{{0, 1}, {0, 2, 3}};
+    REQUIRE(transpose(table_p, table.cheader(), 4, 2) == 3);
+    REQUIRE(table_p == index_table{{0, 0, 0, 1}, {0, 0, 0}, {0, 0, 1}, {0, 0, 1}});
+  }
+
+  SECTION("we can transpose a table with an empty row") {
+    index_table table{{0, 1}, {}, {0, 2, 3}};
+    REQUIRE(transpose(table_p, table.cheader(), 4) == 2);
+    REQUIRE(table_p == index_table{{0, 2}, {0}, {2}, {2}});
+  }
+
+  SECTION("we can transpose an arbitrary table") {
+    index_table table{{0, 1}, {0, 2, 3}, {2, 3, 4}, {0}};
+    REQUIRE(transpose(table_p, table.cheader(), 5) == 5);
+    REQUIRE(table_p == index_table{{0, 1, 3}, {0}, {1, 2}, {1, 2}, {2}});
+  }
+}

--- a/sxt/multiexp/multiproduct_gpu/BUILD
+++ b/sxt/multiexp/multiproduct_gpu/BUILD
@@ -1,0 +1,101 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "block_computation_descriptor",
+    with_test = False,
+    deps = [
+        "//sxt/execution/kernel:block_size",
+    ],
+)
+
+sxt_cc_component(
+    name = "completion",
+    test_deps = [
+        "//sxt/algorithm/reduction:test_reducer",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":block_computation_descriptor",
+        "//sxt/algorithm/base:reducer",
+        "//sxt/base/container:span",
+        "//sxt/base/error:assert",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_computation_descriptor",
+    with_test = False,
+    deps = [
+        ":block_computation_descriptor",
+        "//sxt/execution/kernel:block_size",
+        "//sxt/memory/management:managed_array",
+    ],
+)
+
+sxt_cc_component(
+    name = "computation_setup",
+    impl_deps = [
+        ":multiproduct_computation_descriptor",
+        "//sxt/algorithm/reduction:kernel_fit",
+        "//sxt/execution/kernel:kernel_dims",
+    ],
+    test_deps = [
+        ":multiproduct_computation_descriptor",
+        "//sxt/memory/management:managed_array",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "kernel",
+    is_cuda = True,
+    test_deps = [
+        "//sxt/algorithm/base:gather_mapper",
+        "//sxt/algorithm/reduction:test_reducer",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:managed_device_resource",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":block_computation_descriptor",
+        "//sxt/algorithm/base:reducer",
+        "//sxt/algorithm/reduction:thread_reduction",
+        "//sxt/execution/kernel:launch",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct",
+    is_cuda = True,
+    test_deps = [
+        "//sxt/algorithm/base:gather_mapper",
+        "//sxt/algorithm/reduction:test_reducer",
+        "//sxt/memory/resource:managed_device_resource",
+        "//sxt/base/test:unit_test",
+        "//sxt/execution/schedule:scheduler",
+    ],
+    deps = [
+        ":block_computation_descriptor",
+        ":completion",
+        ":computation_setup",
+        ":kernel",
+        ":multiproduct_computation_descriptor",
+        "//sxt/algorithm/base:reducer",
+        "//sxt/base/container:span",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:stream",
+        "//sxt/execution/async:future",
+        "//sxt/execution/device:synchronization",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/memory/resource:device_resource",
+        "//sxt/memory/resource:pinned_resource",
+    ],
+)

--- a/sxt/multiexp/multiproduct_gpu/block_computation_descriptor.cc
+++ b/sxt/multiexp/multiproduct_gpu/block_computation_descriptor.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h"

--- a/sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h
+++ b/sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <compare>
 #include <cstdint>
 
 #include "sxt/execution/kernel/block_size.h"

--- a/sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h
+++ b/sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h
@@ -1,0 +1,36 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/execution/kernel/block_size.h"
+
+namespace sxt::mtxmpg {
+//--------------------------------------------------------------------------------------------------
+// block_computation_descriptor
+//--------------------------------------------------------------------------------------------------
+struct block_computation_descriptor {
+  unsigned block_offset;
+  unsigned index_first;
+  unsigned n;
+  unsigned reduction_num_blocks;
+  xenk::block_size_t block_size;
+
+  auto operator<=>(const block_computation_descriptor&) const noexcept = default;
+};
+} // namespace sxt::mtxmpg

--- a/sxt/multiexp/multiproduct_gpu/completion.cc
+++ b/sxt/multiexp/multiproduct_gpu/completion.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/completion.h"

--- a/sxt/multiexp/multiproduct_gpu/completion.h
+++ b/sxt/multiexp/multiproduct_gpu/completion.h
@@ -1,0 +1,56 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/algorithm/base/reducer.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h"
+
+namespace sxt::mtxmpg {
+//--------------------------------------------------------------------------------------------------
+// complete_multiproduct
+//--------------------------------------------------------------------------------------------------
+template <algb::reducer Reducer>
+void complete_multiproduct(basct::span<typename Reducer::value_type> products,
+                           basct::cspan<block_computation_descriptor> block_descriptors,
+                           basct::cspan<typename Reducer::value_type> block_results) noexcept {
+  auto num_products = products.size();
+  auto num_blocks = block_descriptors.size();
+  // clang-format off
+  SXT_DEBUG_ASSERT(
+      num_products <= num_blocks &&
+      block_descriptors.size() == num_blocks &&
+      block_results.size() == num_blocks 
+  );
+  // clang-format on
+  size_t block_index = 0;
+  size_t product_index = 0;
+  while (block_index < num_blocks) {
+    auto& descriptor = block_descriptors[block_index];
+    SXT_DEBUG_ASSERT(descriptor.reduction_num_blocks > 0);
+    auto product = block_results[block_index];
+    for (size_t i = 1; i < descriptor.reduction_num_blocks; ++i) {
+      auto block_result_i = block_results[block_index + i];
+      Reducer::accumulate_inplace(product, block_result_i);
+    }
+    block_index += descriptor.reduction_num_blocks;
+    products[product_index++] = product;
+  }
+  SXT_DEBUG_ASSERT(block_index == num_blocks && product_index == num_products);
+}
+} // namespace sxt::mtxmpg

--- a/sxt/multiexp/multiproduct_gpu/completion.t.cc
+++ b/sxt/multiexp/multiproduct_gpu/completion.t.cc
@@ -1,0 +1,69 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/completion.h"
+
+#include <vector>
+
+#include "sxt/algorithm/reduction/test_reducer.h"
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::mtxmpg;
+
+TEST_CASE("we can complete a GPU multiproduct computation") {
+  SECTION("we handle a single reduction with a single block") {
+    block_computation_descriptor descriptors[1];
+    descriptors[0].reduction_num_blocks = 1;
+    uint64_t products[1];
+    uint64_t block_results[] = {123};
+    complete_multiproduct<algr::test_add_reducer>(products, descriptors, block_results);
+    REQUIRE(products[0] == 123);
+  }
+
+  SECTION("we handle a single reduction with multiple blocks") {
+    block_computation_descriptor descriptors[2];
+    descriptors[0].reduction_num_blocks = 2;
+    descriptors[1].reduction_num_blocks = 2;
+    uint64_t products[1];
+    uint64_t block_results[] = {2, 4};
+    complete_multiproduct<algr::test_add_reducer>(products, descriptors, block_results);
+    REQUIRE(products[0] == 6);
+  }
+
+  SECTION("we handle multiple reductions with single blocks") {
+    block_computation_descriptor descriptors[2];
+    descriptors[0].reduction_num_blocks = 1;
+    descriptors[1].reduction_num_blocks = 1;
+    uint64_t products[2];
+    uint64_t block_results[] = {2, 4};
+    complete_multiproduct<algr::test_add_reducer>(products, descriptors, block_results);
+    REQUIRE(products[0] == 2);
+    REQUIRE(products[1] == 4);
+  }
+
+  SECTION("we handle multiple reductions with varying number of blocks") {
+    block_computation_descriptor descriptors[3];
+    descriptors[0].reduction_num_blocks = 1;
+    descriptors[1].reduction_num_blocks = 2;
+    descriptors[2].reduction_num_blocks = 2;
+    uint64_t products[2];
+    uint64_t block_results[] = {2, 4, 10};
+    complete_multiproduct<algr::test_add_reducer>(products, descriptors, block_results);
+    REQUIRE(products[0] == 2);
+    REQUIRE(products[1] == 14);
+  }
+}

--- a/sxt/multiexp/multiproduct_gpu/computation_setup.cc
+++ b/sxt/multiexp/multiproduct_gpu/computation_setup.cc
@@ -1,0 +1,83 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/computation_setup.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "sxt/algorithm/reduction/kernel_fit.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/execution/kernel/kernel_dims.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h"
+
+namespace sxt::mtxmpg {
+//--------------------------------------------------------------------------------------------------
+// fill_block_descriptors
+//--------------------------------------------------------------------------------------------------
+static void fill_block_descriptors(basct::span<block_computation_descriptor> descriptors,
+                                   basct::cspan<unsigned> product_sizes,
+                                   basct::cspan<xenk::kernel_dims> reduction_dims) noexcept {
+  unsigned index_count = 0;
+  unsigned block_count = 0;
+  auto out_iter = descriptors.begin();
+  for (size_t product_index = 0; product_index < product_sizes.size(); ++product_index) {
+    auto n = product_sizes[product_index];
+    auto dims = reduction_dims[product_index];
+    block_computation_descriptor descriptor{
+        .block_offset = block_count,
+        .index_first = index_count,
+        .n = n,
+        .reduction_num_blocks = dims.num_blocks,
+        .block_size = dims.block_size,
+    };
+    out_iter = std::fill_n(out_iter, dims.num_blocks, descriptor);
+    index_count += n;
+    block_count += dims.num_blocks;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// setup_multiproduct_computation
+//--------------------------------------------------------------------------------------------------
+void setup_multiproduct_computation(multiproduct_computation_descriptor& descriptor,
+                                    basct::cspan<unsigned> product_sizes) noexcept {
+  size_t entry_count = 0;
+  size_t block_count = 0;
+  memmg::managed_array<xenk::kernel_dims> reduction_dims(product_sizes.size());
+  descriptor.max_block_size = xenk::block_size_t::v1;
+  for (size_t product_index = 0; product_index < product_sizes.size(); ++product_index) {
+    auto n = product_sizes[product_index];
+    SXT_DEBUG_ASSERT(n > 0);
+    entry_count += n;
+    auto dims = algr::fit_reduction_kernel(n);
+    block_count += dims.num_blocks;
+    descriptor.max_block_size = std::max(descriptor.max_block_size, dims.block_size);
+    reduction_dims[product_index] = dims;
+  }
+  SXT_RELEASE_ASSERT(entry_count <= std::numeric_limits<unsigned>::max(),
+                     "we don't support reductions this large");
+
+  descriptor.num_blocks = block_count;
+
+  // block_descriptors
+  memmg::managed_array<block_computation_descriptor> block_descriptors(
+      block_count, descriptor.block_descriptors.get_allocator());
+  fill_block_descriptors(block_descriptors, product_sizes, reduction_dims);
+  descriptor.block_descriptors = std::move(block_descriptors);
+}
+} // namespace sxt::mtxmpg

--- a/sxt/multiexp/multiproduct_gpu/computation_setup.h
+++ b/sxt/multiexp/multiproduct_gpu/computation_setup.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxmpg {
+struct multiproduct_computation_descriptor;
+
+//--------------------------------------------------------------------------------------------------
+// setup_multiproduct_computation
+//--------------------------------------------------------------------------------------------------
+void setup_multiproduct_computation(multiproduct_computation_descriptor& descriptor,
+                                    basct::cspan<unsigned> product_sizes) noexcept;
+} // namespace sxt::mtxmpg

--- a/sxt/multiexp/multiproduct_gpu/computation_setup.t.cc
+++ b/sxt/multiexp/multiproduct_gpu/computation_setup.t.cc
@@ -1,0 +1,102 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/computation_setup.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h"
+
+using namespace sxt;
+using namespace sxt::mtxmpg;
+
+TEST_CASE("we can fill in the descriptor for a multiproduct computation that runs on the GPU") {
+  multiproduct_computation_descriptor descriptor;
+
+  SECTION("we handle a single product with a single entry") {
+    memmg::managed_array<unsigned> product_sizes = {1};
+    setup_multiproduct_computation(descriptor, product_sizes);
+    multiproduct_computation_descriptor expected{
+        .num_blocks = 1,
+        .max_block_size = xenk::block_size_t::v1,
+        .block_descriptors =
+            {
+                {
+                    .block_offset = 0,
+                    .index_first = 0,
+                    .n = 1,
+                    .reduction_num_blocks = 1,
+                    .block_size = xenk::block_size_t::v1,
+                },
+            },
+    };
+    REQUIRE(descriptor == expected);
+  }
+
+  SECTION("we handle two products with a single entry") {
+    memmg::managed_array<unsigned> product_sizes = {1, 1};
+    setup_multiproduct_computation(descriptor, product_sizes);
+    multiproduct_computation_descriptor expected{
+        .num_blocks = 2,
+        .max_block_size = xenk::block_size_t::v1,
+        .block_descriptors =
+            {
+                {
+                    .block_offset = 0,
+                    .index_first = 0,
+                    .n = 1,
+                    .reduction_num_blocks = 1,
+                    .block_size = xenk::block_size_t::v1,
+                },
+                {
+                    .block_offset = 1,
+                    .index_first = 1,
+                    .n = 1,
+                    .reduction_num_blocks = 1,
+                    .block_size = xenk::block_size_t::v1,
+                },
+            },
+    };
+    REQUIRE(descriptor == expected);
+  }
+
+  SECTION("we handle two products with varying number of entries") {
+    memmg::managed_array<unsigned> product_sizes = {1, 4};
+    setup_multiproduct_computation(descriptor, product_sizes);
+    multiproduct_computation_descriptor expected{
+        .num_blocks = 2,
+        .max_block_size = xenk::block_size_t::v2,
+        .block_descriptors =
+            {
+                {
+                    .block_offset = 0,
+                    .index_first = 0,
+                    .n = 1,
+                    .reduction_num_blocks = 1,
+                    .block_size = xenk::block_size_t::v1,
+                },
+                {
+                    .block_offset = 1,
+                    .index_first = 1,
+                    .n = 4,
+                    .reduction_num_blocks = 1,
+                    .block_size = xenk::block_size_t::v2,
+                },
+            },
+    };
+    REQUIRE(descriptor == expected);
+  }
+}

--- a/sxt/multiexp/multiproduct_gpu/kernel.cc
+++ b/sxt/multiexp/multiproduct_gpu/kernel.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/kernel.h"

--- a/sxt/multiexp/multiproduct_gpu/kernel.h
+++ b/sxt/multiexp/multiproduct_gpu/kernel.h
@@ -37,7 +37,8 @@ __global__ void multiproduct_kernel(typename Reducer::value_type* out,
                                     const unsigned* indexes,
                                     const block_computation_descriptor* block_descriptors) {
   using T = typename Reducer::value_type;
-  extern __shared__ T shared_data[];
+  extern __shared__ T shared_data_p[];
+  T* shared_data = shared_data_p;
   auto thread_index = threadIdx.x;
   auto block_index = blockIdx.x;
   auto descriptor = block_descriptors[block_index];

--- a/sxt/multiexp/multiproduct_gpu/kernel.h
+++ b/sxt/multiexp/multiproduct_gpu/kernel.h
@@ -1,0 +1,62 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cassert>
+#include <concepts>
+
+#include "sxt/algorithm/base/mapper.h"
+#include "sxt/algorithm/base/reducer.h"
+#include "sxt/algorithm/reduction/thread_reduction.h"
+#include "sxt/execution/kernel/launch.h"
+#include "sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h"
+
+namespace sxt::mtxmpg {
+//--------------------------------------------------------------------------------------------------
+// multiproduct_kernel
+//--------------------------------------------------------------------------------------------------
+template <algb::reducer Reducer, algb::mapper Mapper>
+  requires std::same_as<typename Reducer::value_type, typename Mapper::value_type> &&
+           std::constructible_from<Mapper, const typename Reducer::value_type*, const unsigned*>
+__global__ void multiproduct_kernel(typename Reducer::value_type* out,
+                                    const typename Reducer::value_type* generators,
+                                    const unsigned* indexes,
+                                    const block_computation_descriptor* block_descriptors) {
+  using T = typename Reducer::value_type;
+  extern __shared__ T shared_data[];
+  auto thread_index = threadIdx.x;
+  auto block_index = blockIdx.x;
+  auto descriptor = block_descriptors[block_index];
+  Mapper mapper{generators, indexes + descriptor.index_first};
+  // Note: It's expected that most products will be of similar length and
+  // hence share a common block size, but we allow for the same kernel to
+  // compute product reductions with varying block sizes.
+  xenk::launch_kernel(
+      descriptor.block_size,
+      [=]<unsigned BlockSize>(std::integral_constant<unsigned, BlockSize>) noexcept {
+        assert(block_index >= descriptor.block_offset);
+        auto index = (block_index - descriptor.block_offset) * (BlockSize * 2) + thread_index;
+        auto step = BlockSize * 2 * descriptor.reduction_num_blocks;
+        // If BlockSize is less than the maximum block size (the size the kernel was launched with),
+        // then treat the some of the threads as inactive.
+        if (thread_index < BlockSize) {
+          algr::thread_reduce<Reducer, BlockSize>(out + block_index, shared_data, mapper,
+                                                  descriptor.n, step, thread_index, index);
+        }
+      });
+}
+} // namespace sxt::mtxmpg

--- a/sxt/multiexp/multiproduct_gpu/kernel.t.cc
+++ b/sxt/multiexp/multiproduct_gpu/kernel.t.cc
@@ -1,0 +1,125 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/kernel.h"
+
+#include <numeric>
+
+#include "sxt/algorithm/base/gather_mapper.h"
+#include "sxt/algorithm/reduction/test_reducer.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxmpg;
+
+TEST_CASE("we can compute multiproducts using the GPU") {
+  memmg::managed_array<uint64_t> generators(100, memr::get_managed_device_resource());
+  std::iota(generators.begin(), generators.end(), 1);
+
+  using Mapper = algb::gather_mapper<uint64_t>;
+
+  SECTION("we can compute a single multiproduct with a single term") {
+    memmg::managed_array<unsigned> indexes(1, memr::get_managed_device_resource());
+    indexes = {10};
+    memmg::managed_array<block_computation_descriptor> block_descriptors{
+        memr::get_managed_device_resource()};
+    block_descriptors = {
+        {
+            .block_offset = 0,
+            .index_first = 0,
+            .n = 1,
+            .reduction_num_blocks = 1,
+            .block_size = xenk::block_size_t::v1,
+        },
+    };
+    memmg::managed_array<uint64_t> res(block_descriptors.size(),
+                                       memr::get_managed_device_resource());
+    multiproduct_kernel<algr::test_add_reducer, Mapper><<<1, 1, sizeof(uint64_t) * 1>>>(
+        res.data(), generators.data(), indexes.data(), block_descriptors.data());
+    basdv::synchronize_device();
+    memmg::managed_array<uint64_t> expected = {11};
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we can compute multiple multiproducts with varying number of terms") {
+    memmg::managed_array<unsigned> indexes(1, memr::get_managed_device_resource());
+    indexes = {10, 13, 15, 19, 21};
+    memmg::managed_array<block_computation_descriptor> block_descriptors{
+        memr::get_managed_device_resource()};
+    block_descriptors = {
+        {
+            .block_offset = 0,
+            .index_first = 0,
+            .n = 1,
+            .reduction_num_blocks = 1,
+            .block_size = xenk::block_size_t::v1,
+        },
+        {
+            .block_offset = 1,
+            .index_first = 1,
+            .n = 4,
+            .reduction_num_blocks = 1,
+            .block_size = xenk::block_size_t::v2,
+        },
+    };
+    memmg::managed_array<uint64_t> res(block_descriptors.size(),
+                                       memr::get_managed_device_resource());
+    multiproduct_kernel<algr::test_add_reducer, Mapper><<<2, 2, sizeof(uint64_t) * 2>>>(
+        res.data(), generators.data(), indexes.data(), block_descriptors.data());
+    basdv::synchronize_device();
+    memmg::managed_array<uint64_t> expected = {
+        11,
+        14 + 16 + 20 + 22,
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we can compute a multiproduct with more than a single block") {
+    memmg::managed_array<unsigned> indexes(1, memr::get_managed_device_resource());
+    indexes = {1, 3, 5, 7, 14};
+    memmg::managed_array<block_computation_descriptor> block_descriptors{
+        memr::get_managed_device_resource()};
+    block_descriptors = {
+        {
+            .block_offset = 0,
+            .index_first = 0,
+            .n = 5,
+            .reduction_num_blocks = 2,
+            .block_size = xenk::block_size_t::v1,
+        },
+        {
+            .block_offset = 0,
+            .index_first = 0,
+            .n = 5,
+            .reduction_num_blocks = 2,
+            .block_size = xenk::block_size_t::v1,
+        },
+    };
+    memmg::managed_array<uint64_t> res(block_descriptors.size(),
+                                       memr::get_managed_device_resource());
+    multiproduct_kernel<algr::test_add_reducer, Mapper><<<2, 1, sizeof(uint64_t) * 1>>>(
+        res.data(), generators.data(), indexes.data(), block_descriptors.data());
+    basdv::synchronize_device();
+    memmg::managed_array<uint64_t> expected = {
+        2 + 4 + 15,
+        6 + 8,
+    };
+    REQUIRE(res == expected);
+  }
+}

--- a/sxt/multiexp/multiproduct_gpu/multiproduct.cc
+++ b/sxt/multiexp/multiproduct_gpu/multiproduct.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/multiproduct.h"

--- a/sxt/multiexp/multiproduct_gpu/multiproduct.h
+++ b/sxt/multiexp/multiproduct_gpu/multiproduct.h
@@ -1,0 +1,103 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <concepts>
+#include <memory>
+
+#include "sxt/algorithm/base/mapper.h"
+#include "sxt/algorithm/base/reducer.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/device/event.h"
+#include "sxt/base/device/event_utility.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/device/synchronization.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/memory/resource/device_resource.h"
+#include "sxt/memory/resource/pinned_resource.h"
+#include "sxt/multiexp/multiproduct_gpu/completion.h"
+#include "sxt/multiexp/multiproduct_gpu/computation_setup.h"
+#include "sxt/multiexp/multiproduct_gpu/kernel.h"
+#include "sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h"
+
+namespace sxt::mtxmpg {
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+template <algb::reducer Reducer, algb::mapper Mapper>
+  requires std::same_as<typename Reducer::value_type, typename Mapper::value_type> &&
+           std::constructible_from<Mapper, const typename Reducer::value_type*, const unsigned*>
+xena::future<> compute_multiproduct(basct::span<typename Reducer::value_type> products,
+                                    const basdv::stream& stream,
+                                    basct::cspan<typename Reducer::value_type> generators,
+                                    basct::cspan<unsigned> indexes,
+                                    basct::cspan<unsigned> product_sizes) noexcept {
+  auto num_products = products.size();
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      products.size() == num_products &&
+      product_sizes.size() == num_products &&
+      basdv::is_host_pointer(products.data()) &&
+      basdv::is_active_device_pointer(generators.data()) &&
+      basdv::is_active_device_pointer(indexes.data()) &&
+      basdv::is_host_pointer(product_sizes.data())
+      // clang-format on
+  );
+  using T = typename Reducer::value_type;
+  multiproduct_computation_descriptor computation_descriptor{
+      .num_blocks{},
+      .max_block_size{},
+      .block_descriptors{memr::get_pinned_resource()},
+  };
+  setup_multiproduct_computation(computation_descriptor, product_sizes);
+
+  memr::async_device_resource resource{stream};
+
+  // block_descriptors_gpu
+  memmg::managed_array<block_computation_descriptor> block_descriptors_gpu{
+      computation_descriptor.block_descriptors.size(), &resource};
+  basdv::async_copy_host_to_device(block_descriptors_gpu, computation_descriptor.block_descriptors,
+                                   stream);
+
+  // launch kernel
+  memmg::managed_array<T> partial_res_gpu{computation_descriptor.num_blocks, &resource};
+  auto max_block_size = static_cast<unsigned>(computation_descriptor.max_block_size);
+  auto shared_memory = sizeof(T) * max_block_size * 2;
+  multiproduct_kernel<Reducer, Mapper>
+      <<<computation_descriptor.num_blocks, max_block_size, shared_memory, stream>>>(
+          partial_res_gpu.data(), generators.data(), indexes.data(), block_descriptors_gpu.data());
+
+  // partial_res
+  memmg::managed_array<T> partial_res{partial_res_gpu.size(), memr::get_pinned_resource()};
+  basdv::async_copy_device_to_host(partial_res, partial_res_gpu, stream);
+
+  // future
+  // clang-format off
+  return xendv::await_stream(stream).then([
+      products,
+      block_descriptors = std::move(computation_descriptor.block_descriptors),
+      partial_res = std::move(partial_res)
+  ]() noexcept { 
+    complete_multiproduct<Reducer>(products, block_descriptors, partial_res); 
+  });
+  // clang-format on
+}
+} // namespace sxt::mtxmpg

--- a/sxt/multiexp/multiproduct_gpu/multiproduct.t.cc
+++ b/sxt/multiexp/multiproduct_gpu/multiproduct.t.cc
@@ -1,0 +1,103 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/multiproduct.h"
+
+#include <numeric>
+
+#include "sxt/algorithm/base/gather_mapper.h"
+#include "sxt/algorithm/reduction/test_reducer.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxmpg;
+
+TEST_CASE("we can compute multiproducts using the GPU") {
+  basdv::stream stream;
+
+  using Mapper = algb::gather_mapper<uint64_t>;
+
+  size_t max_generators = 10'000;
+  memmg::managed_array<uint64_t> generators{max_generators, memr::get_managed_device_resource()};
+  memmg::managed_array<unsigned> indexes{memr::get_managed_device_resource()};
+  std::iota(generators.begin(), generators.end(), 1);
+
+  SECTION("we can compute a single product with a single element") {
+    indexes = {0};
+    memmg::managed_array<unsigned> product_sizes = {1};
+    memmg::managed_array<uint64_t> res(product_sizes.size());
+    auto fut = compute_multiproduct<algr::test_add_reducer, Mapper>(res, stream, generators,
+                                                                    indexes, product_sizes);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+
+    memmg::managed_array<uint64_t> expected = {1};
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we can compute a single product with two terms") {
+    indexes = {0, 2};
+    memmg::managed_array<unsigned> product_sizes = {2};
+    memmg::managed_array<uint64_t> res(product_sizes.size());
+    auto fut = compute_multiproduct<algr::test_add_reducer, Mapper>(res, stream, generators,
+                                                                    indexes, product_sizes);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+
+    memmg::managed_array<uint64_t> expected = {
+        generators[0] + generators[2],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we can compute multiple products") {
+    indexes = {1, 0, 2, 0, 1, 2};
+    memmg::managed_array<unsigned> product_sizes = {1, 2, 3};
+    memmg::managed_array<uint64_t> res(product_sizes.size());
+    auto fut = compute_multiproduct<algr::test_add_reducer, Mapper>(res, stream, generators,
+                                                                    indexes, product_sizes);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+
+    memmg::managed_array<uint64_t> expected = {
+        generators[1],
+        generators[0] + generators[2],
+        generators[0] + generators[1] + generators[2],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we can compute products with many terms") {
+    unsigned n = 1'000;
+    indexes = memmg::managed_array<unsigned>(n);
+    std::iota(indexes.begin(), indexes.end(), 0);
+    memmg::managed_array<unsigned> product_sizes = {n};
+    memmg::managed_array<uint64_t> res(product_sizes.size());
+    auto fut = compute_multiproduct<algr::test_add_reducer, Mapper>(res, stream, generators,
+                                                                    indexes, product_sizes);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+
+    memmg::managed_array<uint64_t> expected = {
+        n * (n + 1) / 2,
+    };
+    REQUIRE(res == expected);
+  }
+}

--- a/sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.cc
+++ b/sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h"

--- a/sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h
+++ b/sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h
@@ -1,0 +1,34 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/execution/kernel/block_size.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/multiproduct_gpu/block_computation_descriptor.h"
+
+namespace sxt::mtxmpg {
+//--------------------------------------------------------------------------------------------------
+// multiproduct_computation_descriptor
+//--------------------------------------------------------------------------------------------------
+struct multiproduct_computation_descriptor {
+  unsigned num_blocks;
+  xenk::block_size_t max_block_size;
+  memmg::managed_array<block_computation_descriptor> block_descriptors;
+
+  auto operator<=>(const multiproduct_computation_descriptor&) const noexcept = default;
+};
+} // namespace sxt::mtxmpg

--- a/sxt/multiexp/pippenger/BUILD
+++ b/sxt/multiexp/pippenger/BUILD
@@ -1,0 +1,194 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "driver",
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/execution/async:future_fwd",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "test_driver",
+    impl_deps = [
+        "//sxt/base/bit:span_op",
+        "//sxt/base/container:span",
+        "//sxt/base/container:span_void",
+        "//sxt/base/error:assert",
+        "//sxt/base/container:blob_array",
+        "//sxt/execution/async:future",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/multiexp/base:generator_utility",
+        "//sxt/multiexp/base:exponent_sequence",
+    ],
+    with_test = False,
+    deps = [
+        ":driver",
+    ],
+)
+
+sxt_cc_component(
+    name = "exponent_aggregates",
+    with_test = False,
+    deps = [
+        "//sxt/base/container:blob_array",
+    ],
+)
+
+sxt_cc_component(
+    name = "exponent_aggregates_computation",
+    impl_deps = [
+        ":exponent_aggregates",
+        "//sxt/base/num:constexpr_switch",
+        "//sxt/base/num:ceil_log2",
+        "//sxt/base/num:power2_equality",
+        "//sxt/base/type:int",
+        "//sxt/base/bit:count",
+        "//sxt/base/bit:span_op",
+        "//sxt/multiexp/base:exponent_sequence",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_table",
+    impl_deps = [
+        "//sxt/base/bit:count",
+        "//sxt/base/bit:iteration",
+        "//sxt/base/bit:span_op",
+        "//sxt/base/type:int",
+        "//sxt/base/container:blob_array",
+        "//sxt/base/container:span_utility",
+        "//sxt/base/container:stack_array",
+        "//sxt/base/num:divide_up",
+        "//sxt/multiexp/base:digit_utility",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/base/error:assert",
+        "//sxt/base/num:constexpr_switch",
+        "//sxt/base/num:ceil_log2",
+        "//sxt/base/num:power2_equality",
+    ],
+    test_deps = [
+        "//sxt/base/container:blob_array",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/multiexp/base:exponent_sequence_utility",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_decomposition_gpu",
+    impl_deps = [
+        ":multiproduct_decomposition_kernel",
+        "//sxt/base/error:assert",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:stream",
+        "//sxt/base/num:divide_up",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/execution/async:future",
+        "//sxt/execution/async:coroutine",
+    ],
+    test_deps = [
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:managed_device_resource",
+        "//sxt/multiexp/base:exponent_sequence_utility",
+        "//sxt/base/test:unit_test",
+        "//sxt/base/device:synchronization",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/execution/async:future",
+        "//sxt/base/device:stream",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/type:raw_stream",
+        "//sxt/execution/async:future_fwd",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_decomposition_kernel",
+    impl_deps = [
+        "//sxt/base/error:assert",
+        "//sxt/base/num:divide_up",
+        "//sxt/base/num:constexpr_switch",
+        "//sxt/base/num:ceil_log2",
+        "//sxt/base/num:power2_equality",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/type:int",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/execution/async:future",
+        "//sxt/execution/device:synchronization",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/device:synchronization",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/execution/async:future",
+        "//sxt/base/device:stream",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:pinned_resource",
+        "//sxt/memory/resource:managed_device_resource",
+        "//sxt/multiexp/base:exponent_sequence_utility",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/execution/async:future_fwd",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiexponentiation",
+    impl_deps = [
+        ":driver",
+        ":exponent_aggregates",
+        ":exponent_aggregates_computation",
+        ":multiproduct_table",
+        "//sxt/base/bit:span_op",
+        "//sxt/base/container:blob_array",
+        "//sxt/base/num:divide_up",
+        "//sxt/memory/management:managed_array",
+        "//sxt/execution/async:future",
+        "//sxt/multiexp/base:digit_utility",
+        "//sxt/multiexp/index:index_table",
+    ],
+    test_deps = [
+        ":test_driver",
+        "//sxt/base/test:unit_test",
+        "//sxt/execution/async:future",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/multiexp/base:exponent_sequence_utility",
+        "//sxt/multiexp/random:random_multiexponentiation_descriptor",
+        "//sxt/multiexp/random:random_multiexponentiation_generation",
+        "//sxt/multiexp/test:compute_uint64_muladd",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/container:span_void",
+        "//sxt/execution/async:future_fwd",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)

--- a/sxt/multiexp/pippenger/driver.cc
+++ b/sxt/multiexp/pippenger/driver.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/driver.h"

--- a/sxt/multiexp/pippenger/driver.h
+++ b/sxt/multiexp/pippenger/driver.h
@@ -1,0 +1,55 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+#include "sxt/execution/async/future_fwd.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::basct {
+class blob_array;
+class span_cvoid;
+} // namespace sxt::basct
+
+namespace sxt::mtxb {
+class exponent_sequence;
+}
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// driver
+//--------------------------------------------------------------------------------------------------
+class driver {
+public:
+  virtual ~driver() noexcept = default;
+
+  virtual xena::future<memmg::managed_array<void>>
+  compute_multiproduct(mtxi::index_table&& multiproduct_table, basct::span_cvoid generators,
+                       const basct::blob_array& masks, size_t num_inputs) const noexcept = 0;
+
+  virtual xena::future<memmg::managed_array<void>>
+  combine_multiproduct_outputs(xena::future<memmg::managed_array<void>>&& multiproduct,
+                               basct::blob_array&& output_digit_or_all,
+                               basct::cspan<mtxb::exponent_sequence> exponents) const noexcept = 0;
+};
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/exponent_aggregates.cc
+++ b/sxt/multiexp/pippenger/exponent_aggregates.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/exponent_aggregates.h"

--- a/sxt/multiexp/pippenger/exponent_aggregates.h
+++ b/sxt/multiexp/pippenger/exponent_aggregates.h
@@ -1,0 +1,35 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "sxt/base/container/blob_array.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// exponent_aggregates_counts
+//--------------------------------------------------------------------------------------------------
+struct exponent_aggregates {
+  basct::blob_array term_or_all;
+  basct::blob_array output_or_all;
+  std::vector<uint8_t> max_exponent;
+  size_t pop_count;
+};
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/exponent_aggregates_computation.cc
+++ b/sxt/multiexp/pippenger/exponent_aggregates_computation.cc
@@ -1,0 +1,111 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/exponent_aggregates_computation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#include "sxt/base/bit/count.h"
+#include "sxt/base/bit/span_op.h"
+#include "sxt/base/num/ceil_log2.h"
+#include "sxt/base/num/constexpr_switch.h"
+#include "sxt/base/num/power2_equality.h"
+#include "sxt/base/type/int.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/pippenger/exponent_aggregates.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// aggegate_term
+//--------------------------------------------------------------------------------------------------
+static void aggegate_term(exponent_aggregates& aggregates, basct::cspan<uint8_t> term,
+                          size_t output_index, size_t term_index) noexcept {
+  basbt::or_equal(aggregates.term_or_all[term_index], term);
+  basbt::or_equal(aggregates.output_or_all[output_index], term);
+  basbt::max_equal(aggregates.max_exponent, term);
+  aggregates.pop_count += basbt::pop_count(term);
+}
+
+//--------------------------------------------------------------------------------------------------
+// aggregate_unsigned_terms
+//--------------------------------------------------------------------------------------------------
+static void aggregate_unsigned_terms(exponent_aggregates& aggregates, size_t output_index,
+                                     const mtxb::exponent_sequence& sequence) noexcept {
+  auto element_nbytes = sequence.element_nbytes;
+  for (size_t term_index = 0; term_index < sequence.n; ++term_index) {
+    basct::cspan<uint8_t> term{sequence.data + term_index * element_nbytes, element_nbytes};
+    aggegate_term(aggregates, term, output_index, term_index);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// aggregate_signed_terms
+//--------------------------------------------------------------------------------------------------
+template <size_t NumBytes>
+static void aggregate_signed_terms(exponent_aggregates& aggregates, size_t output_index,
+                                   const mtxb::exponent_sequence& sequence) noexcept {
+  for (size_t term_index = 0; term_index < sequence.n; ++term_index) {
+    bast::sized_int_t<NumBytes * 8> x;
+    std::memcpy(reinterpret_cast<uint8_t*>(&x), sequence.data + term_index * NumBytes, NumBytes);
+    auto abs_x = std::abs(x);
+    basct::cspan<uint8_t> term{reinterpret_cast<uint8_t*>(&abs_x), NumBytes};
+    if (x == abs_x) {
+      aggegate_term(aggregates, term, output_index, term_index);
+    } else {
+      aggegate_term(aggregates, term, output_index + 1, term_index);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_exponent_aggregates
+//--------------------------------------------------------------------------------------------------
+void compute_exponent_aggregates(exponent_aggregates& aggregates,
+                                 basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+  size_t max_sequence_length = 0;
+  uint8_t max_element_nbytes = 0;
+  size_t output_count = 0;
+  for (auto& sequence : exponents) {
+    max_sequence_length = std::max(max_sequence_length, sequence.n);
+    max_element_nbytes = std::max(max_element_nbytes, sequence.element_nbytes);
+    output_count += 1 + sequence.is_signed;
+  }
+  aggregates.max_exponent.resize(max_element_nbytes);
+  aggregates.term_or_all.resize(max_sequence_length, max_element_nbytes);
+  aggregates.output_or_all.resize(output_count, max_element_nbytes);
+  aggregates.pop_count = 0;
+
+  size_t output_index = 0;
+  for (size_t sequence_index = 0; sequence_index < exponents.size(); ++sequence_index) {
+    auto sequence = exponents[sequence_index];
+    auto element_num_bytes = sequence.element_nbytes;
+    if (sequence.is_signed) {
+      SXT_DEBUG_ASSERT(basn::is_power2(element_num_bytes));
+      basn::constexpr_switch<4>(
+          basn::ceil_log2(element_num_bytes),
+          [&]<unsigned NumBytesLg2>(std::integral_constant<unsigned, NumBytesLg2>) noexcept {
+            static constexpr auto NumBytes = 1ull << NumBytesLg2;
+            aggregate_signed_terms<NumBytes>(aggregates, output_index, sequence);
+          });
+    } else {
+      aggregate_unsigned_terms(aggregates, output_index, sequence);
+    }
+    output_index += 1 + sequence.is_signed;
+  }
+}
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/exponent_aggregates_computation.h
+++ b/sxt/multiexp/pippenger/exponent_aggregates_computation.h
@@ -1,0 +1,35 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::mtxpi {
+struct exponent_aggregates;
+
+//--------------------------------------------------------------------------------------------------
+// compute_exponent_aggregates
+//--------------------------------------------------------------------------------------------------
+void compute_exponent_aggregates(exponent_aggregates& aggregates,
+                                 basct::cspan<mtxb::exponent_sequence> exponents) noexcept;
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/exponent_aggregates_computation.t.cc
+++ b/sxt/multiexp/pippenger/exponent_aggregates_computation.t.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/exponent_aggregates_computation.h"

--- a/sxt/multiexp/pippenger/multiexponentiation.cc
+++ b/sxt/multiexp/pippenger/multiexponentiation.cc
@@ -1,0 +1,92 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiexponentiation.h"
+
+#include <algorithm>
+#include <limits>
+
+#include "sxt/base/bit/span_op.h"
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/base/digit_utility.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/pippenger/driver.h"
+#include "sxt/multiexp/pippenger/exponent_aggregates.h"
+#include "sxt/multiexp/pippenger/exponent_aggregates_computation.h"
+#include "sxt/multiexp/pippenger/multiproduct_table.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// compute_output_digit_or_all
+//--------------------------------------------------------------------------------------------------
+static void compute_output_digit_or_all(basct::blob_array& output_digit_or_all,
+                                        const basct::blob_array& output_or_all,
+                                        size_t radix_log2) noexcept {
+  auto digit_num_bytes = basn::divide_up(radix_log2, 8ul);
+  auto num_outputs = output_or_all.size();
+  output_digit_or_all.resize(num_outputs, digit_num_bytes);
+  std::vector<uint8_t> digit(digit_num_bytes);
+  for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
+    auto or_all = output_or_all[output_index];
+    auto num_digits = mtxb::count_num_digits(or_all, radix_log2);
+    auto digit_or_all = output_digit_or_all[output_index];
+    for (size_t digit_index = 0; digit_index < num_digits; ++digit_index) {
+      mtxb::extract_digit(digit, or_all, radix_log2, digit_index);
+      basbt::or_equal(digit_or_all, digit);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+static xena::future<memmg::managed_array<void>>
+compute_multiproduct(basct::blob_array& output_digit_or_all, const driver& drv,
+                     basct::span_cvoid generators,
+                     basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+  exponent_aggregates aggregates;
+  compute_exponent_aggregates(aggregates, exponents);
+
+  auto radix_log2 =
+      aggregates.max_exponent.size() * 8 - basbt::count_leading_zeros(aggregates.max_exponent);
+  radix_log2 = std::max(1lu, radix_log2);
+
+  compute_output_digit_or_all(output_digit_or_all, aggregates.output_or_all, radix_log2);
+
+  mtxi::index_table table;
+  auto num_multiproduct_inputs =
+      make_multiproduct_table(table, exponents, aggregates.pop_count, aggregates.term_or_all,
+                              output_digit_or_all, radix_log2);
+
+  return drv.compute_multiproduct(std::move(table), generators, aggregates.term_or_all,
+                                  num_multiproduct_inputs);
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+xena::future<memmg::managed_array<void>>
+compute_multiexponentiation(const driver& drv, basct::span_cvoid generators,
+                            basct::cspan<mtxb::exponent_sequence> exponents) noexcept {
+  basct::blob_array output_digit_or_all;
+  auto multiproduct = compute_multiproduct(output_digit_or_all, drv, generators, exponents);
+  return drv.combine_multiproduct_outputs(std::move(multiproduct), std::move(output_digit_or_all),
+                                          exponents);
+}
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiexponentiation.h
+++ b/sxt/multiexp/pippenger/multiexponentiation.h
@@ -1,0 +1,37 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/container/span_void.h"
+#include "sxt/execution/async/future_fwd.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::mtxpi {
+class driver;
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+xena::future<memmg::managed_array<void>>
+compute_multiexponentiation(const driver& drv, basct::span_cvoid generators,
+                            basct::cspan<mtxb::exponent_sequence> exponents) noexcept;
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiexponentiation.t.cc
+++ b/sxt/multiexp/pippenger/multiexponentiation.t.cc
@@ -1,0 +1,306 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiexponentiation.h"
+
+#include <iostream>
+#include <memory_resource>
+#include <random>
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/base/exponent_sequence_utility.h"
+#include "sxt/multiexp/pippenger/test_driver.h"
+#include "sxt/multiexp/random/random_multiexponentiation_descriptor.h"
+#include "sxt/multiexp/random/random_multiexponentiation_generation.h"
+#include "sxt/multiexp/test/compute_uint64_muladd.h"
+
+using namespace sxt;
+using namespace sxt::mtxpi;
+
+TEST_CASE("we can compute select multiexponentiations") {
+  test_driver drv;
+
+  SECTION("we handle the empty case") {
+    std::vector<mtxb::exponent_sequence> sequences;
+    auto res = compute_multiexponentiation(drv, {}, sequences);
+    REQUIRE(res.value().empty());
+  }
+
+  SECTION("we handle the zero multiplier case") {
+    memmg::managed_array<uint64_t> generators = {123};
+    std::vector<uint8_t> exponents = {0};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = 1, .data = exponents.data()}};
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {0};
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle the 1 multiplier case") {
+    memmg::managed_array<uint64_t> generators = {123};
+    std::vector<uint8_t> exponents = {1};
+    std::vector<mtxb::exponent_sequence> sequences = {mtxb::to_exponent_sequence(exponents)};
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {123};
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle the -1 multiplier case") {
+    memmg::managed_array<uint64_t> generators = {123};
+    std::vector<int8_t> exponents = {-1};
+    std::vector<mtxb::exponent_sequence> sequences = {mtxb::to_exponent_sequence(exponents)};
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {static_cast<uint64_t>(-123)};
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle the 2 multiplier case") {
+    memmg::managed_array<uint64_t> generators = {123};
+    std::vector<uint8_t> exponents = {2};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = 1, .data = exponents.data()}};
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {2 * 123};
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle zero exponents") {
+    memmg::managed_array<uint64_t> generators = {123, 456, 789};
+    std::vector<uint8_t> exponents = {2, 0, 1};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = exponents.size(), .data = exponents.data()}};
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {2 * 123 + 789};
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle a large multiplier") {
+    memmg::managed_array<uint64_t> generators = {123};
+    std::vector<uint64_t> exponents = {1'000'000};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = sizeof(uint64_t),
+         .n = 1,
+         .data = reinterpret_cast<const uint8_t*>(exponents.data())}};
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {123'000'000};
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle multiple sequences") {
+    memmg::managed_array<uint64_t> generators = {123, 321};
+    std::vector<uint8_t> exponents = {2, 3};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = exponents.size(), .data = exponents.data()}};
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {2 * 123 + 3 * 321};
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle multiple outputs") {
+    memmg::managed_array<uint64_t> generators = {123};
+    std::vector<uint8_t> exponents1 = {2};
+    std::vector<uint8_t> exponents2 = {3};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = exponents1.size(), .data = exponents1.data()},
+        {.element_nbytes = 1, .n = exponents2.size(), .data = exponents2.data()},
+    };
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {
+        2 * 123,
+        3 * 123,
+    };
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle a mix of signed and unsigned outputs") {
+    memmg::managed_array<uint64_t> generators = {123};
+    std::vector<uint8_t> exponents1 = {2};
+    std::vector<int8_t> exponents2 = {-3};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents1),
+        mtxb::to_exponent_sequence(exponents2),
+    };
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {
+        2 * 123,
+        static_cast<uint64_t>(-3 * 123),
+    };
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle multiple outputs and multiple sequences") {
+    memmg::managed_array<uint64_t> generators = {123, 321};
+    std::vector<uint8_t> exponents1 = {2, 10};
+    std::vector<uint8_t> exponents2 = {3, 20};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = exponents1.size(), .data = exponents1.data()},
+        {.element_nbytes = 1, .n = exponents2.size(), .data = exponents2.data()},
+    };
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {
+        2 * 123 + 10 * 321,
+        3 * 123 + 20 * 321,
+    };
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle multiple outputs and multiple sequences of different signs") {
+    memmg::managed_array<uint64_t> generators = {123, 321};
+    std::vector<int8_t> exponents1 = {2, -10};
+    std::vector<int8_t> exponents2 = {-3, 20};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents1),
+        mtxb::to_exponent_sequence(exponents2),
+    };
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {
+        static_cast<uint64_t>(2 * 123 - 10 * 321),
+        static_cast<uint64_t>(-3 * 123 + 20 * 321),
+    };
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+
+  SECTION("we handle sequences of varying length") {
+    memmg::managed_array<uint64_t> generators = {123, 321};
+    std::vector<uint8_t> exponents1 = {2};
+    std::vector<uint8_t> exponents2 = {3, 20};
+    std::vector<uint8_t> exponents3 = {10};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = exponents1.size(), .data = exponents1.data()},
+        {.element_nbytes = 1, .n = exponents2.size(), .data = exponents2.data()},
+        {.element_nbytes = 1, .n = exponents3.size(), .data = exponents3.data()},
+    };
+    auto res = compute_multiexponentiation(drv, generators, sequences);
+    memmg::managed_array<uint64_t> expected = {
+        2 * 123,
+        3 * 123 + 20 * 321,
+        10 * 123,
+    };
+    REQUIRE(res.value().as_array<uint64_t>() == expected);
+  }
+}
+
+TEST_CASE("we can compute randomized multiexponentiations") {
+  test_driver drv;
+  std::mt19937 rng{2022};
+
+  std::pmr::monotonic_buffer_resource resource;
+  basct::span<mtxb::exponent_sequence> sequences;
+  basct::span<uint64_t> generators;
+
+  SECTION("we handle a random sequences of varying length") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 1,
+        .min_sequence_length = 0,
+        .max_sequence_length = 100,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 1,
+    };
+    for (size_t i = 0; i < 1000; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = compute_multiexponentiation(drv, generators, sequences);
+      memmg::managed_array<uint64_t> expected(sequences.size());
+      mtxtst::compute_uint64_muladd(expected, generators, sequences);
+      REQUIRE(res.value().as_array<uint64_t>() == expected);
+    }
+  }
+
+  SECTION("we handle multiple outputs and random sequences of length 1") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{.min_num_sequences = 1,
+                                                            .max_num_sequences = 1'000,
+                                                            .min_sequence_length = 1,
+                                                            .max_sequence_length = 1,
+                                                            .min_exponent_num_bytes = 1,
+                                                            .max_exponent_num_bytes = 1};
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = compute_multiexponentiation(drv, generators, sequences);
+      memmg::managed_array<uint64_t> expected(sequences.size());
+      mtxtst::compute_uint64_muladd(expected, generators, sequences);
+      REQUIRE(res.value().as_array<uint64_t>() == expected);
+    }
+  }
+
+  SECTION("we handle multiple outputs and with random sequences of varying length") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{.min_num_sequences = 1,
+                                                            .max_num_sequences = 100,
+                                                            .min_sequence_length = 1,
+                                                            .max_sequence_length = 100,
+                                                            .min_exponent_num_bytes = 1,
+                                                            .max_exponent_num_bytes = 1};
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = compute_multiexponentiation(drv, generators, sequences);
+      memmg::managed_array<uint64_t> expected(sequences.size());
+      mtxtst::compute_uint64_muladd(expected, generators, sequences);
+      REQUIRE(res.value().as_array<uint64_t>() == expected);
+    }
+  }
+
+  SECTION("we handle random sequences of length 1 and varying num_bytes") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{.min_num_sequences = 1,
+                                                            .max_num_sequences = 1,
+                                                            .min_sequence_length = 1,
+                                                            .max_sequence_length = 1,
+                                                            .min_exponent_num_bytes = 1,
+                                                            .max_exponent_num_bytes = 8};
+    for (size_t i = 0; i < 100; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = compute_multiexponentiation(drv, generators, sequences);
+      memmg::managed_array<uint64_t> expected(sequences.size());
+      mtxtst::compute_uint64_muladd(expected, generators, sequences);
+      REQUIRE(res.value().as_array<uint64_t>() == expected);
+    }
+  }
+
+  SECTION("we handle random sequences of varying length and varying num_bytes") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{.min_num_sequences = 1,
+                                                            .max_num_sequences = 1,
+                                                            .min_sequence_length = 1,
+                                                            .max_sequence_length = 100,
+                                                            .min_exponent_num_bytes = 1,
+                                                            .max_exponent_num_bytes = 8};
+    for (size_t i = 0; i < 100; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = compute_multiexponentiation(drv, generators, sequences);
+      memmg::managed_array<uint64_t> expected(sequences.size());
+      mtxtst::compute_uint64_muladd(expected, generators, sequences);
+      REQUIRE(res.value().as_array<uint64_t>() == expected);
+    }
+  }
+
+  SECTION(
+      "we handle multiple outputs and random sequences of varying length and varying num_bytes") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{.min_num_sequences = 1,
+                                                            .max_num_sequences = 100,
+                                                            .min_sequence_length = 1,
+                                                            .max_sequence_length = 100,
+                                                            .min_exponent_num_bytes = 1,
+                                                            .max_exponent_num_bytes = 8};
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = compute_multiexponentiation(drv, generators, sequences);
+      memmg::managed_array<uint64_t> expected(sequences.size());
+      mtxtst::compute_uint64_muladd(expected, generators, sequences);
+      REQUIRE(res.value().as_array<uint64_t>() == expected);
+    }
+  }
+}

--- a/sxt/multiexp/pippenger/multiproduct_decomposition_gpu.cc
+++ b/sxt/multiexp/pippenger/multiproduct_decomposition_gpu.cc
@@ -1,0 +1,98 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiproduct_decomposition_gpu.h"
+
+#include <algorithm>
+#include <memory>
+
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/execution/async/coroutine.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/pippenger/multiproduct_decomposition_kernel.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct_decomposition
+//--------------------------------------------------------------------------------------------------
+xena::future<> compute_multiproduct_decomposition(memmg::managed_array<unsigned>& indexes,
+                                                  basct::span<unsigned> product_sizes,
+                                                  const basdv::stream& stream,
+                                                  mtxb::exponent_sequence exponents) noexcept {
+  auto element_num_bytes = exponents.element_nbytes;
+  auto element_num_bits = 8u * element_num_bytes;
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      product_sizes.size() == element_num_bits &&
+      basdv::is_host_pointer(product_sizes.data())
+      // clang-format on
+  );
+  auto n = exponents.n;
+  std::fill(product_sizes.begin(), product_sizes.end(), 0);
+  indexes.reset();
+  if (n == 0) {
+    co_return;
+  }
+
+  memr::async_device_resource resource{stream};
+
+  // set up exponents
+  memmg::managed_array<uint8_t> exponents_data{&resource};
+  if (!basdv::is_active_device_pointer(exponents.data)) {
+    exponents_data = memmg::managed_array<uint8_t>{
+        n * element_num_bytes,
+        &resource,
+    };
+    basdv::async_memcpy_host_to_device(exponents_data.data(), exponents.data, n * element_num_bytes,
+                                       stream);
+    exponents.data = exponents_data.data();
+  }
+
+  memmg::managed_array<unsigned> block_counts;
+  co_await count_exponent_bits(block_counts, stream, exponents);
+
+  // compute product sizes
+  SXT_DEBUG_ASSERT(block_counts.size() % element_num_bits == 0);
+  unsigned num_blocks = block_counts.size() / element_num_bits;
+  unsigned num_one_bits = 0;
+  for (unsigned bit_index = 0; bit_index < element_num_bits; ++bit_index) {
+    for (unsigned block_index = 0; block_index < num_blocks; ++block_index) {
+      auto& cnt = block_counts[block_index * element_num_bits + bit_index];
+      product_sizes[bit_index] += cnt;
+      auto t = num_one_bits;
+      num_one_bits += cnt;
+      cnt = t;
+    }
+  }
+  if (num_one_bits == 0) {
+    co_return;
+  }
+
+  // rearrange indexes
+  indexes = memmg::managed_array<unsigned>{
+      num_one_bits,
+      indexes.get_allocator(),
+  };
+  SXT_DEBUG_ASSERT(basdv::is_active_device_pointer(indexes.data()));
+  co_await decompose_exponent_bits(indexes, stream, block_counts, exponents);
+}
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiproduct_decomposition_gpu.h
+++ b/sxt/multiexp/pippenger/multiproduct_decomposition_gpu.h
@@ -1,0 +1,39 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/execution/async/future_fwd.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::basdv {
+class stream;
+}
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct_decomposition
+//--------------------------------------------------------------------------------------------------
+xena::future<> compute_multiproduct_decomposition(memmg::managed_array<unsigned>& indexes,
+                                                  basct::span<unsigned> product_sizes,
+                                                  const basdv::stream& stream,
+                                                  mtxb::exponent_sequence exponents) noexcept;
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiproduct_decomposition_gpu.t.cc
+++ b/sxt/multiexp/pippenger/multiproduct_decomposition_gpu.t.cc
@@ -1,0 +1,144 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiproduct_decomposition_gpu.h"
+
+#include "sxt/base/device/stream.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+#include "sxt/multiexp/base/exponent_sequence_utility.h"
+
+using namespace sxt;
+using namespace sxt::mtxpi;
+
+TEST_CASE("we can compute the decomposition that turns a multi-exponentiation problem into a "
+          "multi-product problem") {
+  basdv::stream stream;
+  memmg::managed_array<unsigned> indexes{123, memr::get_managed_device_resource()};
+
+  SECTION("we handle the case of no terms") {
+    std::vector<uint8_t> exponents_data;
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    memmg::managed_array<unsigned> product_sizes(sizeof(exponents_data[0]) * 8u);
+    auto fut = compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+
+    REQUIRE(indexes.empty());
+
+    memmg::managed_array<unsigned> expected_product_sizes = {0, 0, 0, 0, 0, 0, 0, 0};
+    REQUIRE(product_sizes == expected_product_sizes);
+  }
+
+  SECTION("we handle the case of exponents with no bits") {
+    std::vector<uint8_t> exponents_data = {0};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    memmg::managed_array<unsigned> product_sizes(sizeof(exponents_data[0]) * 8u);
+    auto fut = compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+
+    REQUIRE(indexes.empty());
+
+    memmg::managed_array<unsigned> expected_product_sizes = {0, 0, 0, 0, 0, 0, 0, 0};
+    REQUIRE(product_sizes == expected_product_sizes);
+  }
+
+  SECTION("we handle a single term with a single 1 bit") {
+    std::vector<uint8_t> exponents_data = {1};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    memmg::managed_array<unsigned> product_sizes(sizeof(exponents_data[0]) * 8u);
+    auto fut = compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+
+    memmg::managed_array<unsigned> expected_indexes = {0};
+    REQUIRE(indexes == expected_indexes);
+
+    memmg::managed_array<unsigned> expected_product_sizes = {1, 0, 0, 0, 0, 0, 0, 0};
+    REQUIRE(product_sizes == expected_product_sizes);
+  }
+
+  SECTION("we handle a single term with multiple bits set") {
+    std::vector<uint8_t> exponents_data = {0b11};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    memmg::managed_array<unsigned> product_sizes(sizeof(exponents_data[0]) * 8u);
+    auto fut = compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+
+    memmg::managed_array<unsigned> expected_indexes = {0, 0};
+    REQUIRE(indexes == expected_indexes);
+
+    memmg::managed_array<unsigned> expected_product_sizes = {1, 1, 0, 0, 0, 0, 0, 0};
+    REQUIRE(product_sizes == expected_product_sizes);
+  }
+
+  SECTION("we handle multiple terms with a single bit set") {
+    std::vector<uint8_t> exponents_data = {1, 0, 1};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    memmg::managed_array<unsigned> product_sizes(sizeof(exponents_data[0]) * 8u);
+    auto fut = compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+
+    memmg::managed_array<unsigned> expected_indexes = {0, 2};
+    REQUIRE(indexes == expected_indexes);
+
+    memmg::managed_array<unsigned> expected_product_sizes = {2, 0, 0, 0, 0, 0, 0, 0};
+    REQUIRE(product_sizes == expected_product_sizes);
+  }
+
+  SECTION("we handle multiple terms with multiple bits set") {
+    std::vector<uint8_t> exponents_data = {0b10, 0, 0b11, 0b100};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    memmg::managed_array<unsigned> product_sizes(sizeof(exponents_data[0]) * 8u);
+    auto fut = compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+
+    memmg::managed_array<unsigned> expected_indexes = {2, 0, 2, 3};
+    REQUIRE(indexes == expected_indexes);
+
+    memmg::managed_array<unsigned> expected_product_sizes = {1, 2, 1, 0, 0, 0, 0, 0};
+    REQUIRE(product_sizes == expected_product_sizes);
+  }
+
+  SECTION("we handle signed terms") {
+    std::vector<int8_t> exponents_data = {-1, 0, 3};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    memmg::managed_array<unsigned> product_sizes(sizeof(exponents_data[0]) * 8u);
+    auto fut = compute_multiproduct_decomposition(indexes, product_sizes, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+
+    auto sign_bit = 1u << 31;
+    memmg::managed_array<unsigned> expected_indexes = {sign_bit, 2, 2};
+    REQUIRE(indexes == expected_indexes);
+
+    memmg::managed_array<unsigned> expected_product_sizes = {2, 1, 0, 0, 0, 0, 0, 0};
+    REQUIRE(product_sizes == expected_product_sizes);
+  }
+}

--- a/sxt/multiexp/pippenger/multiproduct_decomposition_kernel.cc
+++ b/sxt/multiexp/pippenger/multiproduct_decomposition_kernel.cc
@@ -1,0 +1,261 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiproduct_decomposition_kernel.h"
+
+#include <cassert>
+#include <memory>
+
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/num/ceil_log2.h"
+#include "sxt/base/num/constexpr_switch.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/base/num/power2_equality.h"
+#include "sxt/base/type/int.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/device/synchronization.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// count_kernel
+//--------------------------------------------------------------------------------------------------
+static __global__ void count_kernel(unsigned* counters, const uint8_t* data, unsigned n) {
+  unsigned element_num_bytes = blockDim.x;
+  unsigned element_num_bits = element_num_bytes * 8u;
+  unsigned num_blocks = gridDim.x;
+  unsigned block_index = blockIdx.x;
+  unsigned byte_index = threadIdx.x;
+  unsigned bit_offset = threadIdx.y;
+  unsigned bit_index = 8u * byte_index + bit_offset;
+
+  auto k = basn::divide_up(n, num_blocks);
+  auto first = k * block_index;
+  assert(first < n);
+  auto last = umin(first + k, n);
+
+  data += first * element_num_bytes + byte_index;
+
+  const auto mask = 1u << bit_offset;
+  unsigned count = 0;
+  for (unsigned i = first; i < last; ++i) {
+    auto byte = *data;
+    count += static_cast<unsigned>((byte & mask) != 0);
+    data += element_num_bytes;
+  }
+  counters[block_index * element_num_bits + bit_index] = count;
+}
+
+//--------------------------------------------------------------------------------------------------
+// signed_count_kernel
+//--------------------------------------------------------------------------------------------------
+template <size_t NumBytes>
+static __global__ void signed_count_kernel(unsigned* counters, const uint8_t* data, unsigned n) {
+  unsigned element_num_bytes = blockDim.x;
+  unsigned element_num_bits = element_num_bytes * 8u;
+  unsigned num_blocks = gridDim.x;
+  unsigned block_index = blockIdx.x;
+  unsigned byte_index = threadIdx.x;
+  unsigned bit_offset = threadIdx.y;
+  unsigned bit_index = 8u * byte_index + bit_offset;
+
+  auto k = basn::divide_up(n, num_blocks);
+  auto first = k * block_index;
+  assert(first < n);
+  auto last = umin(first + k, n);
+
+  data += first * element_num_bytes;
+
+  const auto mask = 1u << bit_offset;
+  unsigned count = 0;
+  for (unsigned i = first; i < last; ++i) {
+    // Note: we can assume the data pointer is properly aligned
+    auto element = abs(*reinterpret_cast<const bast::sized_int_t<NumBytes * 8u>*>(data));
+    auto byte = reinterpret_cast<uint8_t*>(&element)[byte_index];
+    count += static_cast<unsigned>((byte & mask) != 0);
+    data += element_num_bytes;
+  }
+  counters[block_index * element_num_bits + bit_index] = count;
+}
+
+//--------------------------------------------------------------------------------------------------
+// decomposition_kernel
+//--------------------------------------------------------------------------------------------------
+static __global__ void decomposition_kernel(unsigned* out, const unsigned* offsets,
+                                            const uint8_t* data, unsigned n) {
+  unsigned element_num_bytes = blockDim.x;
+  unsigned element_num_bits = element_num_bytes * 8u;
+  unsigned num_blocks = gridDim.x;
+  unsigned block_index = blockIdx.x;
+  unsigned byte_index = threadIdx.x;
+  unsigned bit_offset = threadIdx.y;
+  unsigned bit_index = 8u * byte_index + bit_offset;
+
+  auto k = basn::divide_up(n, num_blocks);
+  auto first = k * block_index;
+  assert(first < n);
+  auto last = umin(first + k, n);
+
+  data += first * element_num_bytes + byte_index;
+  out = out + offsets[block_index * element_num_bits + bit_index];
+
+  const auto mask = 1u << bit_offset;
+  unsigned count = 0;
+  for (unsigned i = first; i < last; ++i) {
+    auto byte = *data;
+    auto is_one = static_cast<unsigned>((byte & mask) != 0);
+    if (is_one == 1) {
+      out[count] = i;
+    }
+    count += is_one;
+    data += element_num_bytes;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// signed_decomposition_kernel
+//--------------------------------------------------------------------------------------------------
+template <size_t NumBytes>
+static __global__ void signed_decomposition_kernel(unsigned* out, const unsigned* offsets,
+                                                   const uint8_t* data, unsigned n) {
+  unsigned element_num_bytes = blockDim.x;
+  unsigned element_num_bits = element_num_bytes * 8u;
+  unsigned num_blocks = gridDim.x;
+  unsigned block_index = blockIdx.x;
+  unsigned byte_index = threadIdx.x;
+  unsigned bit_offset = threadIdx.y;
+  unsigned bit_index = 8u * byte_index + bit_offset;
+
+  auto k = basn::divide_up(n, num_blocks);
+  auto first = k * block_index;
+  assert(first < n);
+  auto last = umin(first + k, n);
+
+  data += first * element_num_bytes;
+  out = out + offsets[block_index * element_num_bits + bit_index];
+
+  const auto mask = 1u << bit_offset;
+  unsigned count = 0;
+  for (unsigned i = first; i < last; ++i) {
+    // Note: we can assume the data pointer is properly aligned
+    auto element = *reinterpret_cast<const bast::sized_int_t<NumBytes * 8u>*>(data);
+    auto abs_element = abs(element);
+    auto sign_bit = (1u << 31) * static_cast<unsigned>(element != abs_element);
+
+    auto byte = reinterpret_cast<uint8_t*>(&abs_element)[byte_index];
+
+    auto is_one = static_cast<unsigned>((byte & mask) != 0);
+    if (is_one == 1) {
+      out[count] = sign_bit | i;
+    }
+    count += is_one;
+    data += element_num_bytes;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// decompose_exponent_bits
+//--------------------------------------------------------------------------------------------------
+xena::future<> decompose_exponent_bits(basct::span<unsigned> indexes, const basdv::stream& stream,
+                                       basct::cspan<unsigned> offsets,
+                                       const mtxb::exponent_sequence& exponents) noexcept {
+  unsigned element_num_bytes = exponents.element_nbytes;
+  unsigned element_num_bits = 8u * element_num_bytes;
+  auto n = exponents.n;
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      basdv::is_active_device_pointer(indexes.data()) &&
+      basdv::is_host_pointer(offsets.data()) &&
+      basdv::is_active_device_pointer(exponents.data)
+      // clang-format on
+  );
+  auto num_blocks = offsets.size() / element_num_bits;
+  memr::async_device_resource resource{stream};
+
+  // set up offsets_dev
+  memmg::managed_array<unsigned> offsets_dev{offsets.size(), &resource};
+  basdv::async_copy_host_to_device(offsets_dev, offsets, stream);
+
+  // launch kernel
+  if (exponents.is_signed == 0) {
+    decomposition_kernel<<<dim3(num_blocks, 1, 1), dim3(element_num_bytes, 8, 1), 0, stream>>>(
+        indexes.data(), offsets_dev.data(), exponents.data, static_cast<unsigned>(n));
+  } else {
+    SXT_DEBUG_ASSERT(basn::is_power2(element_num_bytes));
+    basn::constexpr_switch<4>(
+        basn::ceil_log2(element_num_bytes),
+        [&]<unsigned NumBytesLg2>(std::integral_constant<unsigned, NumBytesLg2>) noexcept {
+          static constexpr auto NumBytes = 1ull << NumBytesLg2;
+          signed_decomposition_kernel<NumBytes>
+              <<<dim3(num_blocks, 1, 1), dim3(element_num_bytes, 8, 1), 0, stream>>>(
+                  indexes.data(), offsets_dev.data(), exponents.data, static_cast<unsigned>(n));
+        });
+  }
+
+  // set up future
+  return xendv::await_stream(stream);
+}
+
+//--------------------------------------------------------------------------------------------------
+// count_exponent_bits
+//--------------------------------------------------------------------------------------------------
+xena::future<> count_exponent_bits(memmg::managed_array<unsigned>& block_counts,
+                                   const basdv::stream& stream,
+                                   const mtxb::exponent_sequence& exponents) noexcept {
+  unsigned element_num_bytes = exponents.element_nbytes;
+  unsigned element_num_bits = 8u * element_num_bytes;
+  auto n = exponents.n;
+  SXT_DEBUG_ASSERT(basdv::is_active_device_pointer(exponents.data));
+  memr::async_device_resource resource{stream};
+  auto num_blocks = std::min(n, 128ul);
+  auto num_iterations = basn::divide_up(n, num_blocks);
+  num_blocks = basn::divide_up(n, num_iterations);
+
+  block_counts = memmg::managed_array<unsigned>{
+      num_blocks * element_num_bits,
+      block_counts.get_allocator(),
+  };
+  SXT_DEBUG_ASSERT(basdv::is_host_pointer(block_counts.data()));
+
+  // set up block_counts_dev
+  memmg::managed_array<unsigned> block_counts_dev{block_counts.size(), &resource};
+
+  // launch kernel
+  if (exponents.is_signed == 0) {
+    count_kernel<<<dim3(num_blocks, 1, 1), dim3(element_num_bytes, 8, 1), 0, stream>>>(
+        block_counts_dev.data(), exponents.data, static_cast<unsigned>(n));
+  } else {
+    SXT_DEBUG_ASSERT(basn::is_power2(element_num_bytes));
+    basn::constexpr_switch<4>(
+        basn::ceil_log2(element_num_bytes),
+        [&]<unsigned NumBytesLg2>(std::integral_constant<unsigned, NumBytesLg2>) noexcept {
+          static constexpr auto NumBytes = 1ull << NumBytesLg2;
+          signed_count_kernel<NumBytes>
+              <<<dim3(num_blocks, 1, 1), dim3(element_num_bytes, 8, 1), 0, stream>>>(
+                  block_counts_dev.data(), exponents.data, static_cast<unsigned>(n));
+        });
+  }
+
+  // transfer counts back to host
+  basdv::async_copy_device_to_host(block_counts, block_counts_dev, stream);
+
+  // set up future
+  return xendv::await_stream(stream);
+}
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiproduct_decomposition_kernel.h
+++ b/sxt/multiexp/pippenger/multiproduct_decomposition_kernel.h
@@ -1,0 +1,45 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/execution/async/future_fwd.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::basdv {
+class stream;
+}
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// decompose_exponent_bits
+//--------------------------------------------------------------------------------------------------
+xena::future<> decompose_exponent_bits(basct::span<unsigned> indexes, const basdv::stream& stream,
+                                       basct::cspan<unsigned> offsets,
+                                       const mtxb::exponent_sequence& exponents) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// count_exponent_bits
+//--------------------------------------------------------------------------------------------------
+xena::future<> count_exponent_bits(memmg::managed_array<unsigned>& block_counts,
+                                   const basdv::stream& stream,
+                                   const mtxb::exponent_sequence& exponents) noexcept;
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiproduct_decomposition_kernel.t.cc
+++ b/sxt/multiexp/pippenger/multiproduct_decomposition_kernel.t.cc
@@ -1,0 +1,88 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiproduct_decomposition_kernel.h"
+
+#include <algorithm>
+#include <numeric>
+
+#include "sxt/base/device/stream.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+#include "sxt/memory/resource/pinned_resource.h"
+#include "sxt/multiexp/base/exponent_sequence_utility.h"
+
+using namespace sxt;
+using namespace sxt::mtxpi;
+
+TEST_CASE("we can decompose the bits in a multi-exponentiation") {
+  basdv::stream stream;
+  memmg::managed_array<unsigned> block_counts{memr::get_pinned_resource()};
+  memmg::managed_array<uint8_t> exponents_data{memr::get_managed_device_resource()};
+  memmg::managed_array<int32_t> signed_exponents_data{memr::get_managed_device_resource()};
+
+  SECTION("we handle the case of no 1 bits") {
+    exponents_data = {0};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    auto fut = count_exponent_bits(block_counts, stream, exponents);
+    xens::get_scheduler().run();
+    REQUIRE(std::count(block_counts.begin(), block_counts.end(), 0) == block_counts.size());
+  }
+
+  SECTION("we handle an exponent with a single bit") {
+    exponents_data = {1};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    auto fut = count_exponent_bits(block_counts, stream, exponents);
+    xens::get_scheduler().run();
+    basdv::synchronize_device();
+    REQUIRE(std::count(block_counts.begin(), block_counts.end(), 0) == block_counts.size() - 1);
+    REQUIRE(block_counts[0] == 1);
+  }
+
+  SECTION("we handle an signed exponent with a single bit") {
+    signed_exponents_data = {-1};
+    auto exponents = mtxb::to_exponent_sequence(signed_exponents_data);
+    auto fut = count_exponent_bits(block_counts, stream, exponents);
+    xens::get_scheduler().run();
+    basdv::synchronize_device();
+    REQUIRE(std::count(block_counts.begin(), block_counts.end(), 0) == block_counts.size() - 1);
+    REQUIRE(block_counts[0] == 1);
+  }
+
+  SECTION("we handle an exponent with a single bit at a non-zero offset") {
+    exponents_data = {0b10};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    auto fut = count_exponent_bits(block_counts, stream, exponents);
+    xens::get_scheduler().run();
+    basdv::synchronize_device();
+    REQUIRE(std::count(block_counts.begin(), block_counts.end(), 0) == block_counts.size() - 1);
+    REQUIRE(block_counts[1] == 1);
+  }
+
+  SECTION("we handle multiple entries in the exponent") {
+    exponents_data = {0, 0b10};
+    auto exponents = mtxb::to_exponent_sequence(exponents_data);
+    auto fut = count_exponent_bits(block_counts, stream, exponents);
+    xens::get_scheduler().run();
+    basdv::synchronize_device();
+    REQUIRE(std::count(block_counts.begin(), block_counts.end(), 0) == block_counts.size() - 1);
+    REQUIRE(block_counts[9] == 1);
+  }
+}

--- a/sxt/multiexp/pippenger/multiproduct_table.cc
+++ b/sxt/multiexp/pippenger/multiproduct_table.cc
@@ -1,0 +1,259 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiproduct_table.h"
+
+#include <algorithm>
+
+#include "sxt/base/bit/count.h"
+#include "sxt/base/bit/iteration.h"
+#include "sxt/base/bit/span_op.h"
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/container/span_utility.h"
+#include "sxt/base/container/stack_array.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/num/ceil_log2.h"
+#include "sxt/base/num/constexpr_switch.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/base/num/power2_equality.h"
+#include "sxt/base/type/int.h"
+#include "sxt/multiexp/base/digit_utility.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/index/index_table.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// init_multiproduct_table
+//--------------------------------------------------------------------------------------------------
+static void init_multiproduct_table(mtxi::index_table& table, size_t max_entries,
+                                    const basct::blob_array& output_digit_or_all) noexcept {
+  size_t row_count = 0;
+  for (auto digit : output_digit_or_all) {
+    row_count += basbt::pop_count(digit);
+  }
+  table.reshape(row_count, max_entries + 2 * row_count);
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_multiproduct_output_rows_impl
+//--------------------------------------------------------------------------------------------------
+static uint64_t* init_multiproduct_output_rows_impl(basct::span<basct::span<uint64_t>> rows,
+                                                    size_t& multiproduct_output_index,
+                                                    uint64_t* entry_data,
+                                                    basct::span<size_t> row_counts) noexcept {
+  for (auto count : row_counts) {
+    if (count == 0) {
+      continue;
+    }
+    auto output_index = multiproduct_output_index++;
+    auto& row = rows[output_index];
+    row = {entry_data, 2};
+    row[0] = output_index;
+    row[1] = 0;
+    entry_data += count + 2;
+  }
+  return entry_data;
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_multiproduct_output_rows
+//--------------------------------------------------------------------------------------------------
+static uint64_t* init_multiproduct_output_rows(basct::span<basct::span<uint64_t>> rows,
+                                               size_t& multiproduct_output_index,
+                                               uint64_t* entry_data, basct::span<size_t> row_counts,
+                                               const mtxb::exponent_sequence& sequence,
+                                               size_t digit_num_bytes) noexcept {
+  SXT_STACK_ARRAY(digit, digit_num_bytes, uint8_t);
+  std::fill(row_counts.begin(), row_counts.end(), 0);
+  auto radix_log2 = row_counts.size();
+  for (size_t term_index = 0; term_index < sequence.n; ++term_index) {
+    basct::cspan<uint8_t> e{sequence.data + term_index * sequence.element_nbytes,
+                            sequence.element_nbytes};
+    auto digit_last = mtxb::get_last_digit(e, radix_log2);
+    for (size_t digit_index = 0; digit_index < digit_last; ++digit_index) {
+      mtxb::extract_digit(digit, e, radix_log2, digit_index);
+      basbt::for_each_bit(digit, [&](size_t bit_index) noexcept { ++row_counts[bit_index]; });
+    }
+  }
+  return init_multiproduct_output_rows_impl(rows, multiproduct_output_index, entry_data,
+                                            row_counts);
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_signed_multiproduct_output_rows
+//--------------------------------------------------------------------------------------------------
+template <size_t NumBytes>
+static uint64_t* init_signed_multiproduct_output_rows(basct::span<basct::span<uint64_t>> rows,
+                                                      size_t& multiproduct_output_index,
+                                                      uint64_t* entry_data,
+                                                      basct::span<size_t> row_counts,
+                                                      const mtxb::exponent_sequence& sequence,
+                                                      size_t digit_num_bytes) noexcept {
+  SXT_STACK_ARRAY(digit, digit_num_bytes, uint8_t);
+  std::fill(row_counts.begin(), row_counts.end(), 0);
+  auto radix_log2 = row_counts.size() / 2u;
+  for (size_t term_index = 0; term_index < sequence.n; ++term_index) {
+    basct::cspan<uint8_t> e{sequence.data + term_index * sequence.element_nbytes,
+                            sequence.element_nbytes};
+    bast::sized_int_t<NumBytes * 8> x;
+    std::copy(e.begin(), e.end(), reinterpret_cast<uint8_t*>(&x));
+    auto abs_x = std::abs(x);
+    e = {reinterpret_cast<uint8_t*>(&abs_x), NumBytes};
+    auto offset = static_cast<size_t>(abs_x != x) * radix_log2;
+    auto digit_last = mtxb::get_last_digit(e, radix_log2);
+    for (size_t digit_index = 0; digit_index < digit_last; ++digit_index) {
+      mtxb::extract_digit(digit, e, radix_log2, digit_index);
+      basbt::for_each_bit(digit,
+                          [&](size_t bit_index) noexcept { ++row_counts[offset + bit_index]; });
+    }
+  }
+  return init_multiproduct_output_rows_impl(rows, multiproduct_output_index, entry_data,
+                                            row_counts);
+}
+
+//--------------------------------------------------------------------------------------------------
+// fill_from_sequence
+//--------------------------------------------------------------------------------------------------
+static size_t fill_from_sequence(uint64_t*& entry_data, basct::span<basct::span<uint64_t>> rows,
+                                 size_t& multiproduct_output_index,
+                                 const mtxb::exponent_sequence& sequence,
+                                 basct::cspan<uint8_t> digit_or_all,
+                                 const basct::blob_array& term_or_all, size_t radix_log2) noexcept {
+  auto digit_num_bytes = basn::divide_up(radix_log2, 8ul);
+  SXT_STACK_ARRAY(index_array, radix_log2, size_t);
+  auto bit_index_first = multiproduct_output_index;
+  entry_data = init_multiproduct_output_rows(rows, multiproduct_output_index, entry_data,
+                                             index_array, sequence, digit_num_bytes);
+  make_digit_index_array(index_array, bit_index_first, digit_or_all);
+  size_t input_first = 0;
+  SXT_STACK_ARRAY(digit, digit_num_bytes, uint8_t);
+  for (size_t term_index = 0; term_index < sequence.n; ++term_index) {
+    basct::cspan<uint8_t> e{sequence.data + term_index * sequence.element_nbytes,
+                            sequence.element_nbytes};
+    auto digit_last = mtxb::get_last_digit(e, radix_log2);
+    size_t input_offset = 0;
+    for (size_t digit_index = 0; digit_index < digit_last; ++digit_index) {
+      mtxb::extract_digit(digit, e, radix_log2, digit_index);
+      basbt::for_each_bit(digit, [&](size_t bit_index) noexcept {
+        auto& row = rows[index_array[bit_index]];
+        auto sz = row.size();
+        row = {row.data(), row.size() + 1};
+        row[sz] = input_first + input_offset;
+      });
+      input_offset += static_cast<size_t>(
+          !mtxb::is_digit_zero(term_or_all[term_index], radix_log2, digit_index));
+    }
+    input_first += mtxb::count_nonzero_digits(term_or_all[term_index], radix_log2);
+  }
+  return input_first;
+}
+
+//--------------------------------------------------------------------------------------------------
+// fill_from_signed_sequence
+//--------------------------------------------------------------------------------------------------
+template <size_t NumBytes>
+static size_t fill_from_signed_sequence(
+    uint64_t*& entry_data, basct::span<basct::span<uint64_t>> rows,
+    size_t& multiproduct_output_index, const mtxb::exponent_sequence& sequence,
+    basct::cspan<uint8_t> pos_digit_or_all, basct::cspan<uint8_t> neg_digit_or_all,
+    const basct::blob_array& term_or_all, size_t radix_log2) noexcept {
+  auto digit_num_bytes = basn::divide_up(radix_log2, 8ul);
+  SXT_STACK_ARRAY(index_array, radix_log2 * 2u, size_t);
+  auto bit_index_first = multiproduct_output_index;
+  entry_data = init_signed_multiproduct_output_rows<NumBytes>(
+      rows, multiproduct_output_index, entry_data, index_array, sequence, digit_num_bytes);
+  auto pos_bit_index_last = make_digit_index_array(basct::subspan(index_array, 0, radix_log2),
+                                                   bit_index_first, pos_digit_or_all);
+  make_digit_index_array(basct::subspan(index_array, radix_log2), pos_bit_index_last,
+                         neg_digit_or_all);
+  size_t input_first = 0;
+  SXT_STACK_ARRAY(digit, digit_num_bytes, uint8_t);
+  for (size_t term_index = 0; term_index < sequence.n; ++term_index) {
+    basct::cspan<uint8_t> e{sequence.data + term_index * sequence.element_nbytes,
+                            sequence.element_nbytes};
+    bast::sized_int_t<NumBytes * 8> x;
+    std::copy(e.begin(), e.end(), reinterpret_cast<uint8_t*>(&x));
+    auto abs_x = std::abs(x);
+    e = {reinterpret_cast<uint8_t*>(&abs_x), NumBytes};
+    auto digit_last = mtxb::get_last_digit(e, radix_log2);
+    size_t input_offset = 0;
+    auto bit_index_offset = static_cast<size_t>(x != abs_x) * radix_log2;
+    for (size_t digit_index = 0; digit_index < digit_last; ++digit_index) {
+      mtxb::extract_digit(digit, e, radix_log2, digit_index);
+      basbt::for_each_bit(digit, [&](size_t bit_index) noexcept {
+        auto& row = rows[index_array[bit_index + bit_index_offset]];
+        auto sz = row.size();
+        row = {row.data(), row.size() + 1};
+        row[sz] = input_first + input_offset;
+      });
+      input_offset += static_cast<size_t>(
+          !mtxb::is_digit_zero(term_or_all[term_index], radix_log2, digit_index));
+    }
+    input_first += mtxb::count_nonzero_digits(term_or_all[term_index], radix_log2);
+  }
+  return input_first;
+}
+
+//--------------------------------------------------------------------------------------------------
+// make_digit_index_array
+//--------------------------------------------------------------------------------------------------
+size_t make_digit_index_array(basct::span<size_t> array, size_t first,
+                              basct::cspan<uint8_t> or_all) noexcept {
+  basbt::for_each_bit(or_all, [&](size_t index) noexcept { array[index] = first++; });
+  return first;
+}
+
+//--------------------------------------------------------------------------------------------------
+// make_multiproduct_table
+//--------------------------------------------------------------------------------------------------
+size_t make_multiproduct_table(mtxi::index_table& table,
+                               basct::cspan<mtxb::exponent_sequence> exponents, size_t max_entries,
+                               const basct::blob_array& term_or_all,
+                               const basct::blob_array& output_digit_or_all,
+                               size_t radix_log2) noexcept {
+  init_multiproduct_table(table, max_entries, output_digit_or_all);
+
+  auto entry_data = table.entry_data();
+  auto rows = table.header();
+  size_t multiproduct_output_index = 0;
+  size_t max_inputs = 0;
+  size_t input_first;
+  size_t output_index = 0;
+  for (size_t sequence_index = 0; sequence_index < exponents.size(); ++sequence_index) {
+    auto sequence = exponents[sequence_index];
+    auto element_num_bytes = sequence.element_nbytes;
+    if (sequence.is_signed) {
+      SXT_DEBUG_ASSERT(basn::is_power2(element_num_bytes));
+      basn::constexpr_switch<4>(
+          basn::ceil_log2(element_num_bytes),
+          [&]<unsigned NumBytesLg2>(std::integral_constant<unsigned, NumBytesLg2>) noexcept {
+            static constexpr auto NumBytes = 1ull << NumBytesLg2;
+            input_first = fill_from_signed_sequence<NumBytes>(
+                entry_data, rows, multiproduct_output_index, sequence,
+                output_digit_or_all[output_index], output_digit_or_all[output_index + 1],
+                term_or_all, radix_log2);
+          });
+      output_index += 2;
+    } else {
+      input_first = fill_from_sequence(entry_data, rows, multiproduct_output_index, sequence,
+                                       output_digit_or_all[output_index], term_or_all, radix_log2);
+      ++output_index;
+    }
+    max_inputs = std::max(input_first, max_inputs);
+  }
+  return max_inputs;
+}
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiproduct_table.h
+++ b/sxt/multiexp/pippenger/multiproduct_table.h
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::basct {
+class blob_array;
+}
+namespace sxt::mtxb {
+class exponent_sequence;
+} // namespace sxt::mtxb
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// make_digit_index_array
+//--------------------------------------------------------------------------------------------------
+size_t make_digit_index_array(basct::span<size_t> array, size_t first,
+                              basct::cspan<uint8_t> or_all) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// make_multiproduct_table
+//--------------------------------------------------------------------------------------------------
+size_t make_multiproduct_table(mtxi::index_table& table,
+                               basct::cspan<mtxb::exponent_sequence> exponents, size_t max_entries,
+                               const basct::blob_array& term_or_all,
+                               const basct::blob_array& output_digit_or_all,
+                               size_t radix_log2) noexcept;
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/multiproduct_table.t.cc
+++ b/sxt/multiexp/pippenger/multiproduct_table.t.cc
@@ -1,0 +1,244 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/multiproduct_table.h"
+
+#include <vector>
+
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/base/exponent_sequence_utility.h"
+#include "sxt/multiexp/index/index_table.h"
+
+using namespace sxt;
+using namespace sxt::mtxpi;
+
+TEST_CASE("we can build an index array from digit bits") {
+  std::array<size_t, 16> index_array = {};
+
+  SECTION("we handle the empty case") {
+    uint8_t blob[] = {0};
+    make_digit_index_array(index_array, 1, blob);
+    std::array<size_t, 16> expected_index_array = {};
+    REQUIRE(index_array == expected_index_array);
+  }
+
+  SECTION("we handle the case of a single bit") {
+    uint8_t blob[] = {0b1};
+    make_digit_index_array(index_array, 1, blob);
+    std::array<size_t, 16> expected_index_array = {1};
+    REQUIRE(index_array == expected_index_array);
+
+    blob[0] = 0b10;
+    index_array[0] = 99;
+    make_digit_index_array(index_array, 1, blob);
+    expected_index_array = {99, 1};
+    REQUIRE(index_array == expected_index_array);
+  }
+
+  SECTION("we handle multiple bits") {
+    uint8_t blob[] = {0b1010};
+    make_digit_index_array(index_array, 1, blob);
+    std::array<size_t, 16> expected_index_array = {0, 1, 0, 2};
+    REQUIRE(index_array == expected_index_array);
+  }
+}
+
+TEST_CASE("we can construct a table for the multiproduct computation") {
+  mtxi::index_table table;
+
+  basct::blob_array term_or_all(0, 8);
+  basct::blob_array output_digit_or_all(0, 8);
+
+  SECTION("we handle the empty case") {
+    make_multiproduct_table(table, {}, 100, term_or_all, output_digit_or_all, 3);
+    REQUIRE(table == mtxi::index_table{});
+  }
+
+  SECTION("we handle the case of zero entries") {
+    std::vector<uint8_t> exponents = {0};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(1, 8);
+    output_digit_or_all.resize(1, 8);
+    REQUIRE(0 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{});
+  }
+
+  SECTION("we handle the case of a single exponentiation of 1") {
+    std::vector<uint8_t> exponents = {1};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(1, 8);
+    output_digit_or_all.resize(1, 8);
+    term_or_all[0][0] = 1;
+    output_digit_or_all[0][0] = 1;
+    REQUIRE(1 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}});
+  }
+
+  SECTION("we handle the case of a single singed exponentiation of 1") {
+    std::vector<int8_t> exponents = {1};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(1, 8);
+    output_digit_or_all.resize(2, 8);
+    term_or_all[0][0] = 1;
+    output_digit_or_all[0][0] = 1;
+    REQUIRE(1 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}});
+  }
+
+  SECTION("we handle the case of a single singed exponentiation of -1") {
+    std::vector<int8_t> exponents = {-1};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(1, 8);
+    output_digit_or_all.resize(2, 8);
+    term_or_all[0][0] = 1;
+    output_digit_or_all[1][0] = 1;
+    REQUIRE(1 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}});
+  }
+
+  SECTION("we handle the case of two exponentiations of 1") {
+    std::vector<uint8_t> exponents = {1, 1};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(2, 8);
+    term_or_all[0][0] = 1;
+    term_or_all[1][0] = 1;
+    output_digit_or_all.resize(1, 8);
+    output_digit_or_all[0][0] = 1;
+    REQUIRE(2 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0, 1}});
+  }
+
+  SECTION("we handle the case of two exponentiations of 1 and -1") {
+    std::vector<int8_t> exponents = {1, -1};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(2, 8);
+    term_or_all[0][0] = 1;
+    term_or_all[1][0] = 1;
+    output_digit_or_all.resize(2, 8);
+    output_digit_or_all[0][0] = 1;
+    output_digit_or_all[1][0] = 1;
+    REQUIRE(2 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}, {1, 0, 1}});
+  }
+
+  SECTION("we handle the case of a single exponentiation of 2") {
+    std::vector<uint8_t> exponents = {2};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(1, 8);
+    term_or_all[0][0] = 2;
+    output_digit_or_all.resize(1, 8);
+    output_digit_or_all[0][0] = 2;
+    REQUIRE(1 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}});
+  }
+
+  SECTION("we handle the case of a single exponentiation of 3") {
+    std::vector<uint8_t> exponents = {3};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(1, 8);
+    term_or_all[0][0] = 3;
+    output_digit_or_all.resize(1, 8);
+    output_digit_or_all[0][0] = 3;
+    REQUIRE(1 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}, {1, 0, 0}});
+  }
+
+  SECTION("we handle the case of two exponentiations of 1 and 2") {
+    std::vector<uint8_t> exponents = {1, 2};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(2, 8);
+    term_or_all[0][0] = 1;
+    term_or_all[1][0] = 2;
+    output_digit_or_all.resize(1, 8);
+    output_digit_or_all[0][0] = 0b11;
+    REQUIRE(2 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 3));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}, {1, 0, 1}});
+  }
+
+  SECTION("we handle the case of two digits") {
+    std::vector<uint8_t> exponents = {3};
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+    term_or_all.resize(1, 8);
+    term_or_all[0][0] = 3;
+    output_digit_or_all.resize(1, 8);
+    output_digit_or_all[0][0] = 1;
+    REQUIRE(2 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 1));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0, 1}});
+  }
+
+  SECTION("we handle digits sizes of multiple bytes") {
+    std::vector<uint16_t> exponents = {0b1010111100110100};
+    auto exponents_bytes = reinterpret_cast<uint8_t*>(exponents.data());
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+
+    term_or_all.resize(1, 16);
+    term_or_all[0][0] = exponents_bytes[0];
+    term_or_all[0][1] = exponents_bytes[1];
+
+    output_digit_or_all.resize(1, 16);
+    output_digit_or_all[0][0] = exponents_bytes[0];
+    output_digit_or_all[0][1] = exponents_bytes[1];
+
+    REQUIRE(1 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 16));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0},
+                                       {1, 0, 0},
+                                       {2, 0, 0},
+                                       {3, 0, 0},
+                                       {4, 0, 0},
+                                       {5, 0, 0},
+                                       {6, 0, 0},
+                                       {7, 0, 0},
+                                       {8, 0, 0}});
+  }
+
+  SECTION("we handle digits sizes of multiple bytes and multiple digits") {
+    std::vector<uint16_t> exponents = {0b1010111100110101};
+    auto exponents_bytes = reinterpret_cast<uint8_t*>(exponents.data());
+    std::vector<mtxb::exponent_sequence> sequence = {mtxb::to_exponent_sequence(exponents)};
+
+    term_or_all.resize(1, 16);
+    term_or_all[0][0] = exponents_bytes[0];
+    term_or_all[0][1] = exponents_bytes[1];
+
+    output_digit_or_all.resize(1, 16);
+    output_digit_or_all[0][0] = exponents_bytes[0] | 0b101011;
+    output_digit_or_all[0][1] = 0b11;
+
+    REQUIRE(2 ==
+            make_multiproduct_table(table, sequence, 100, term_or_all, output_digit_or_all, 10));
+    REQUIRE(table == mtxi::index_table{{0, 0, 0, 1},
+                                       {1, 0, 1},
+                                       {2, 0, 0},
+                                       {3, 0, 1},
+                                       {4, 0, 0},
+                                       {5, 0, 0, 1},
+                                       {6, 0, 0},
+                                       {7, 0, 0}});
+  }
+}

--- a/sxt/multiexp/pippenger/test_driver.cc
+++ b/sxt/multiexp/pippenger/test_driver.cc
@@ -1,0 +1,95 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger/test_driver.h"
+
+#include "sxt/base/bit/span_op.h"
+#include "sxt/base/container/blob_array.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/container/span_void.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/base/generator_utility.h"
+#include "sxt/multiexp/index/index_table.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+xena::future<memmg::managed_array<void>>
+test_driver::compute_multiproduct(mtxi::index_table&& multiproduct_table,
+                                  basct::span_cvoid generators, const basct::blob_array& masks,
+                                  size_t num_inputs) const noexcept {
+  memmg::managed_array<uint64_t> inputs_data;
+  basct::cspan<uint64_t> inputs;
+  auto generators_p =
+      basct::cspan<uint64_t>{static_cast<const uint64_t*>(generators.data()), generators.size()};
+  if (num_inputs == generators.size()) {
+    inputs = generators_p;
+  } else {
+    inputs_data = memmg::managed_array<uint64_t>(num_inputs);
+    mtxb::filter_generators<uint64_t>(inputs_data, generators_p, masks);
+    inputs = inputs_data;
+  }
+  memmg::managed_array<uint64_t> outputs(multiproduct_table.num_rows());
+  for (size_t row_index = 0; row_index < multiproduct_table.num_rows(); ++row_index) {
+    auto products = multiproduct_table.header()[row_index];
+    SXT_RELEASE_ASSERT(!products.empty());
+    auto& output = outputs[row_index];
+    output = 0;
+    for (size_t product_index = 2; product_index < products.size(); ++product_index) {
+      auto input = products[product_index];
+      SXT_RELEASE_ASSERT(input < inputs.size());
+      output += inputs[input];
+    }
+  }
+  return xena::make_ready_future(std::move(static_cast<memmg::managed_array<void>&>(outputs)));
+}
+
+//--------------------------------------------------------------------------------------------------
+// combine_multiproduct_outputs
+//--------------------------------------------------------------------------------------------------
+xena::future<memmg::managed_array<void>> test_driver::combine_multiproduct_outputs(
+    xena::future<memmg::managed_array<void>>&& multiproduct,
+    basct::blob_array&& output_digit_or_all,
+    basct::cspan<mtxb::exponent_sequence> exponents) const noexcept {
+  auto& multiproduct_array = multiproduct.value();
+  basct::cspan<uint64_t> inputs{static_cast<uint64_t*>(multiproduct_array.data()),
+                                multiproduct_array.size()};
+  memmg::managed_array<uint64_t> outputs(exponents.size());
+  size_t input_index = 0;
+  size_t multiproduct_index = 0;
+  for (size_t sequence_index = 0; sequence_index < exponents.size(); ++sequence_index) {
+    auto& sequence = exponents[sequence_index];
+    auto& output = outputs[sequence_index];
+    output = 0;
+    basbt::for_each_bit(output_digit_or_all[multiproduct_index++], [&](size_t pos) noexcept {
+      SXT_DEBUG_ASSERT(input_index < inputs.size());
+      output += (1ull << pos) * inputs[input_index++];
+    });
+    if (!sequence.is_signed) {
+      continue;
+    }
+    basbt::for_each_bit(output_digit_or_all[multiproduct_index++], [&](size_t pos) noexcept {
+      SXT_DEBUG_ASSERT(input_index < inputs.size());
+      output -= (1ull << pos) * inputs[input_index++];
+    });
+  }
+  return xena::make_ready_future(std::move(static_cast<memmg::managed_array<void>&>(outputs)));
+}
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger/test_driver.h
+++ b/sxt/multiexp/pippenger/test_driver.h
@@ -1,0 +1,39 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "sxt/multiexp/pippenger/driver.h"
+
+namespace sxt::mtxpi {
+//--------------------------------------------------------------------------------------------------
+// test_driver
+//--------------------------------------------------------------------------------------------------
+class test_driver final : public driver {
+public:
+  // driver
+  xena::future<memmg::managed_array<void>>
+  compute_multiproduct(mtxi::index_table&& multiproduct_table, basct::span_cvoid generators,
+                       const basct::blob_array& masks, size_t num_inputs) const noexcept override;
+
+  xena::future<memmg::managed_array<void>> combine_multiproduct_outputs(
+      xena::future<memmg::managed_array<void>>&& multiproduct,
+      basct::blob_array&& output_digit_or_all,
+      basct::cspan<mtxb::exponent_sequence> exponents) const noexcept override;
+};
+} // namespace sxt::mtxpi

--- a/sxt/multiexp/pippenger_multiprod/BUILD
+++ b/sxt/multiexp/pippenger_multiprod/BUILD
@@ -1,0 +1,214 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "active_count",
+    impl_deps = [
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "active_offset",
+    impl_deps = [
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "driver",
+    impl_deps = [
+        "//sxt/base/container:span_void",
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "test_driver",
+    impl_deps = [
+        "//sxt/base/bit:iteration",
+        "//sxt/base/container:span_void",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/index:clump2_descriptor",
+        "//sxt/multiexp/index:clump2_marker_utility",
+        "//sxt/base/error:assert",
+        "//sxt/base/error:panic",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    with_test = False,
+    deps = [
+        ":driver",
+    ],
+)
+
+sxt_cc_component(
+    name = "clump_inputs",
+    impl_deps = [
+        ":active_offset",
+        ":driver",
+        ":prune",
+        ":reduction_stats",
+        "//sxt/base/container:span_void",
+        "//sxt/multiexp/index:clump2_descriptor",
+        "//sxt/multiexp/index:clump2_descriptor_utility",
+        "//sxt/multiexp/index:clump2_marker_utility",
+        "//sxt/multiexp/index:marker_transformation",
+        "//sxt/multiexp/index:reindex",
+    ],
+    test_deps = [
+        ":reduction_stats",
+        ":test_driver",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/index:index_table",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "clump_outputs",
+    impl_deps = [
+        ":active_offset",
+        "//sxt/multiexp/index:clump2_descriptor",
+        "//sxt/multiexp/index:clump2_descriptor_utility",
+        "//sxt/multiexp/index:clump2_marker_utility",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/multiexp/index:index_table_utility",
+        "//sxt/multiexp/index:marker_transformation",
+        "//sxt/multiexp/index:reindex",
+        "//sxt/multiexp/index:transpose",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/multiexp/index:index_table",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_params",
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "multiproduct_params_computation",
+    impl_deps = [
+        ":multiproduct_params",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct",
+    impl_deps = [
+        ":clump_inputs",
+        ":clump_outputs",
+        ":driver",
+        ":multiproduct_params",
+        ":multiproduct_params_computation",
+        ":partition_inputs",
+        ":product_table_normalization",
+        ":prune",
+        ":reduction_stats",
+        "//sxt/base/container:span_void",
+        "//sxt/base/iterator:counting_iterator",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        ":multiproduct_params",
+        ":test_driver",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/multiexp/random:random_multiproduct_descriptor",
+        "//sxt/multiexp/random:random_multiproduct_generation",
+        "//sxt/multiexp/random:int_generation",
+        "//sxt/multiexp/test:add_ints",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "partition_inputs",
+    impl_deps = [
+        ":active_offset",
+        ":driver",
+        ":prune",
+        ":reduction_stats",
+        "//sxt/base/container:span_void",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/multiexp/index:partition_marker_utility",
+        "//sxt/multiexp/index:marker_transformation",
+        "//sxt/multiexp/index:reindex",
+    ],
+    test_deps = [
+        ":reduction_stats",
+        ":test_driver",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/index:index_table",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "product_table_normalization",
+    impl_deps = [
+        "//sxt/multiexp/index:index_table",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/multiexp/index:index_table",
+    ],
+)
+
+sxt_cc_component(
+    name = "prune",
+    impl_deps = [
+        ":active_count",
+        "//sxt/base/iterator:counting_iterator",
+        "//sxt/base/error:assert",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/multiexp/index:index_table",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "reduction_stats",
+    with_test = False,
+)

--- a/sxt/multiexp/pippenger_multiprod/active_count.cc
+++ b/sxt/multiexp/pippenger_multiprod/active_count.cc
@@ -1,0 +1,34 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/active_count.h"
+
+#include "sxt/base/error/assert.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// count_active_entries
+//--------------------------------------------------------------------------------------------------
+void count_active_entries(basct::span<size_t> counts,
+                          basct::cspan<basct::cspan<uint64_t>> rows) noexcept {
+  for (auto row : rows) {
+    SXT_DEBUG_ASSERT(row.size() >= 2 && row.size() >= 2 + row[1]);
+    for (size_t active_index = 2 + row[1]; active_index < row.size(); ++active_index) {
+      ++counts[row[active_index]];
+    }
+  }
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/active_count.h
+++ b/sxt/multiexp/pippenger_multiprod/active_count.h
@@ -1,0 +1,36 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// count_active_entries
+//--------------------------------------------------------------------------------------------------
+void count_active_entries(basct::span<size_t> counts,
+                          basct::cspan<basct::cspan<uint64_t>> rows) noexcept;
+
+inline void count_active_entries(basct::span<size_t> counts,
+                                 basct::cspan<basct::span<uint64_t>> rows) noexcept {
+  count_active_entries(counts,
+                       {reinterpret_cast<const basct::cspan<uint64_t>*>(rows.data()), rows.size()});
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/active_count.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/active_count.t.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/active_count.h"

--- a/sxt/multiexp/pippenger_multiprod/active_offset.cc
+++ b/sxt/multiexp/pippenger_multiprod/active_offset.cc
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/active_offset.h"
+
+#include "sxt/base/error/assert.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// compute_active_offset
+//--------------------------------------------------------------------------------------------------
+size_t compute_active_offset(basct::cspan<uint64_t> row) noexcept {
+  SXT_DEBUG_ASSERT(row.size() >= 2 && row.size() >= 2 + row[1]);
+  return 2 + row[1];
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/active_offset.h
+++ b/sxt/multiexp/pippenger_multiprod/active_offset.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// compute_active_offset
+//--------------------------------------------------------------------------------------------------
+size_t compute_active_offset(basct::cspan<uint64_t> row) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/active_offset.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/active_offset.t.cc
@@ -1,0 +1,33 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/active_offset.h"
+
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt::mtxpmp;
+
+TEST_CASE("we can compute the offset where the active entries start") {
+  SECTION("we handle the case of no inactive entries") {
+    REQUIRE(compute_active_offset(std::vector<uint64_t>{0, 0}) == 2);
+  }
+
+  SECTION("we handle the case of inactive entries") {
+    REQUIRE(compute_active_offset(std::vector<uint64_t>{0, 1, 9, 10}) == 3);
+  }
+}

--- a/sxt/multiexp/pippenger_multiprod/clump_inputs.cc
+++ b/sxt/multiexp/pippenger_multiprod/clump_inputs.cc
@@ -1,0 +1,55 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/clump_inputs.h"
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/container/span_void.h"
+#include "sxt/multiexp/index/clump2_descriptor.h"
+#include "sxt/multiexp/index/clump2_descriptor_utility.h"
+#include "sxt/multiexp/index/clump2_marker_utility.h"
+#include "sxt/multiexp/index/marker_transformation.h"
+#include "sxt/multiexp/index/reindex.h"
+#include "sxt/multiexp/pippenger_multiprod/active_offset.h"
+#include "sxt/multiexp/pippenger_multiprod/driver.h"
+#include "sxt/multiexp/pippenger_multiprod/prune.h"
+#include "sxt/multiexp/pippenger_multiprod/reduction_stats.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// clump_inputs
+//--------------------------------------------------------------------------------------------------
+void clump_inputs(basct::span_void inout, reduction_stats& stats,
+                  basct::span<basct::span<uint64_t>> products, size_t& num_inactive_outputs,
+                  size_t& num_inactive_inputs, const driver& drv, size_t clump_size) noexcept {
+  mtxi::clump2_descriptor clump2_descriptor;
+  mtxi::init_clump2_descriptor(clump2_descriptor, clump_size);
+  auto num_entries_p = mtxi::apply_marker_transformation(
+      products.subspan(num_inactive_outputs),
+      [clump2_descriptor](basct::span<uint64_t>& indexes) noexcept {
+        return mtxi::consume_clump2_marker(indexes, clump2_descriptor);
+      },
+      compute_active_offset);
+  stats.prev_num_terms = num_entries_p;
+  std::vector<uint64_t> markers(num_entries_p);
+  basct::span<uint64_t> markers_view{markers};
+  mtxi::reindex_rows(products.subspan(num_inactive_outputs), markers_view, compute_active_offset);
+  stats.num_terms = markers_view.size();
+  markers.resize(markers_view.size());
+  prune_rows(products, markers, num_inactive_outputs, num_inactive_inputs);
+  drv.apply_clump2_operation(inout, markers, clump2_descriptor);
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/clump_inputs.h
+++ b/sxt/multiexp/pippenger_multiprod/clump_inputs.h
@@ -1,0 +1,38 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::basct {
+class span_void;
+}
+
+namespace sxt::mtxpmp {
+class driver;
+struct reduction_stats;
+
+//--------------------------------------------------------------------------------------------------
+// clump_inputs
+//--------------------------------------------------------------------------------------------------
+void clump_inputs(basct::span_void inout, reduction_stats& stats,
+                  basct::span<basct::span<uint64_t>> products, size_t& num_inactive_outputs,
+                  size_t& num_inactive_inputs, const driver& drv, size_t clump_size) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/clump_inputs.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/clump_inputs.t.cc
@@ -1,0 +1,140 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/clump_inputs.h"
+
+#include <cstdint>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/pippenger_multiprod/reduction_stats.h"
+#include "sxt/multiexp/pippenger_multiprod/test_driver.h"
+
+using namespace sxt;
+using namespace sxt::mtxpmp;
+
+TEST_CASE("we can clump the inputs of a multiproduct") {
+  test_driver drv;
+  reduction_stats stats;
+
+  SECTION("clumping a single entry product does nothing") {
+    memmg::managed_array<uint64_t> inputs{10};
+    mtxi::index_table products{{0, 0, 0}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    clump_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs, drv,
+                 2);
+
+    memmg::managed_array<uint64_t> expected_inputs{10};
+    REQUIRE(inputs == expected_inputs);
+
+    REQUIRE(stats.prev_num_terms == 1);
+    REQUIRE(stats.num_terms == 1);
+
+    REQUIRE(num_inactive_outputs == 1);
+    REQUIRE(num_inactive_inputs == 1);
+
+    mtxi::index_table expected_products{{0, 1, 0}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("clumping a product with two entries adds them together") {
+    memmg::managed_array<uint64_t> inputs{10, 5};
+    mtxi::index_table products{{0, 0, 0, 1}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    clump_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs, drv,
+                 2);
+
+    REQUIRE(inputs[0] == 15);
+
+    REQUIRE(stats.prev_num_terms == 1);
+    REQUIRE(stats.num_terms == 1);
+
+    REQUIRE(num_inactive_outputs == 1);
+    REQUIRE(num_inactive_inputs == 1);
+
+    mtxi::index_table expected_products{{0, 1, 0}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("we can clump a table with two rows and three elements") {
+    memmg::managed_array<uint64_t> inputs{10, 5, 999};
+    mtxi::index_table products{{0, 0, 0, 1}, {1, 0, 1}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    clump_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs, drv,
+                 2);
+
+    REQUIRE(inputs[0] == 15);
+    REQUIRE(inputs[1] == 5);
+
+    REQUIRE(stats.prev_num_terms == 2);
+    REQUIRE(stats.num_terms == 2);
+
+    REQUIRE(num_inactive_outputs == 2);
+    REQUIRE(num_inactive_inputs == 2);
+
+    mtxi::index_table expected_products{{0, 1, 0}, {1, 1, 1}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("identical sets of two elements within a clump across rows are "
+          "reindexed to the same input") {
+    memmg::managed_array<uint64_t> inputs{10, 5, 20, 999, 999};
+    mtxi::index_table products{{0, 0, 0, 1}, {0, 0, 0, 1, 2}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    clump_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs, drv,
+                 2);
+
+    REQUIRE(inputs[0] == 20);
+    REQUIRE(inputs[1] == 15);
+
+    REQUIRE(stats.prev_num_terms == 3);
+    REQUIRE(stats.num_terms == 2);
+
+    REQUIRE(num_inactive_outputs == 0);
+    REQUIRE(num_inactive_inputs == 1);
+
+    mtxi::index_table expected_products{{0, 0, 0}, {0, 1, 0, 0}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("we can clump with size 3") {
+    memmg::managed_array<uint64_t> inputs{10, 5, 6, 20, 999};
+    mtxi::index_table products{{0, 0, 0, 1}, {1, 0, 1, 3}, {2, 0, 2}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    clump_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs, drv,
+                 3);
+
+    REQUIRE(inputs[0] == 15);
+    REQUIRE(inputs[1] == 5);
+    REQUIRE(inputs[2] == 6);
+    REQUIRE(inputs[3] == 20);
+
+    REQUIRE(stats.prev_num_terms == 4);
+    REQUIRE(stats.num_terms == 4);
+
+    REQUIRE(num_inactive_outputs == 3);
+    REQUIRE(num_inactive_inputs == 4);
+
+    mtxi::index_table expected_products{{0, 1, 0}, {1, 2, 1, 3}, {2, 1, 2}};
+    REQUIRE(products == expected_products);
+  }
+}

--- a/sxt/multiexp/pippenger_multiprod/clump_outputs.cc
+++ b/sxt/multiexp/pippenger_multiprod/clump_outputs.cc
@@ -1,0 +1,95 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/clump_outputs.h"
+
+#include <iostream>
+
+#include "sxt/base/container/span.h"
+#include "sxt/multiexp/index/clump2_descriptor.h"
+#include "sxt/multiexp/index/clump2_descriptor_utility.h"
+#include "sxt/multiexp/index/clump2_marker_utility.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/index/index_table_utility.h"
+#include "sxt/multiexp/index/marker_transformation.h"
+#include "sxt/multiexp/index/reindex.h"
+#include "sxt/multiexp/index/transpose.h"
+#include "sxt/multiexp/pippenger_multiprod/active_offset.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// compute_clumped_output_table
+//--------------------------------------------------------------------------------------------------
+bool compute_clumped_output_table(mtxi::index_table& table, std::vector<uint64_t>& output_clumps,
+                                  basct::cspan<basct::cspan<uint64_t>> rows,
+                                  size_t num_active_inputs, size_t clump_size) noexcept {
+  mtxi::index_table table_p;
+  auto naive_product_count =
+      mtxi::transpose(table_p, rows, num_active_inputs, 0, compute_active_offset);
+  mtxi::clump2_descriptor clump2_descriptor;
+  mtxi::init_clump2_descriptor(clump2_descriptor, clump_size);
+  auto num_entries_p = mtxi::apply_marker_transformation(
+      table_p.header(), [clump2_descriptor](basct::span<uint64_t>& indexes) noexcept {
+        return mtxi::consume_clump2_marker(indexes, clump2_descriptor);
+      });
+  output_clumps.resize(num_entries_p);
+  basct::span<uint64_t> markers{output_clumps};
+  mtxi::reindex_rows(table_p.header(), markers);
+  if (naive_product_count == num_entries_p - markers.size()) {
+    // we didn't reduce the problem to anything simpler
+    return false;
+  }
+  output_clumps.resize(markers.size());
+  mtxi::transpose(table, table_p.cheader(), output_clumps.size(), 2);
+  for (size_t row_index = 0; row_index < table.num_rows(); ++row_index) {
+    table.header()[row_index][0] = row_index;
+  }
+  return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+// rewrite_multiproducts_with_output_clumps
+//--------------------------------------------------------------------------------------------------
+void rewrite_multiproducts_with_output_clumps(basct::span<basct::span<uint64_t>> rows,
+                                              basct::cspan<uint64_t> output_clumps,
+                                              size_t clump_size) noexcept {
+  mtxi::clump2_descriptor clump2_descriptor;
+  mtxi::init_clump2_descriptor(clump2_descriptor, clump_size);
+
+  // clear active entries
+  for (auto& row : rows) {
+    row = {row.data(), 2 + row[1]};
+  }
+
+  // fill table
+  for (size_t marker_index = 0; marker_index < output_clumps.size(); ++marker_index) {
+    uint64_t clump_index, index1, index2;
+    mtxi::unpack_clump2_marker(clump_index, index1, index2, clump2_descriptor,
+                               output_clumps[marker_index]);
+    auto clump_first = clump_size * clump_index;
+    auto& row1 = rows[clump_first + index1];
+    auto sz = row1.size();
+    row1 = {row1.data(), sz + 1};
+    row1[sz] = marker_index;
+    if (index1 != index2) {
+      auto& row2 = rows[clump_first + index2];
+      auto sz = row2.size();
+      row2 = {row2.data(), sz + 1};
+      row2[sz] = marker_index;
+    }
+  }
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/clump_outputs.h
+++ b/sxt/multiexp/pippenger_multiprod/clump_outputs.h
@@ -1,0 +1,54 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// compute_clumped_output_table
+//--------------------------------------------------------------------------------------------------
+bool compute_clumped_output_table(mtxi::index_table& table, std::vector<uint64_t>& output_clumps,
+                                  basct::cspan<basct::cspan<uint64_t>> rows,
+                                  size_t num_active_inputs, size_t clump_size) noexcept;
+
+inline bool compute_clumped_output_table(mtxi::index_table& table,
+                                         std::vector<uint64_t>& output_clumps,
+                                         basct::span<basct::span<uint64_t>> rows,
+                                         size_t num_active_inputs, size_t clump_size) noexcept {
+  return compute_clumped_output_table(table, output_clumps,
+                                      {
+                                          reinterpret_cast<basct::cspan<uint64_t>*>(rows.data()),
+                                          rows.size(),
+                                      },
+                                      num_active_inputs, clump_size);
+}
+
+//--------------------------------------------------------------------------------------------------
+// rewrite_multiproducts_with_output_clumps
+//--------------------------------------------------------------------------------------------------
+void rewrite_multiproducts_with_output_clumps(basct::span<basct::span<uint64_t>> rows,
+                                              basct::cspan<uint64_t> output_clumps,
+                                              size_t clump_size) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/clump_outputs.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/clump_outputs.t.cc
@@ -1,0 +1,99 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/clump_outputs.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/index_table.h"
+
+using namespace sxt;
+using namespace sxt::mtxpmp;
+
+TEST_CASE("we compute a clumped output table") {
+  mtxi::index_table table_p;
+  std::vector<uint64_t> output_clumps;
+
+  SECTION("we can clump a table with a single entry") {
+    mtxi::index_table table{{0, 0, 0}};
+    REQUIRE(!compute_clumped_output_table(table_p, output_clumps, table.cheader(), 1, 2));
+  }
+
+  SECTION("we can clump a table with a single row") {
+    mtxi::index_table table{{0, 0, 0, 1}};
+    REQUIRE(!compute_clumped_output_table(table_p, output_clumps, table.cheader(), 2, 2));
+  }
+
+  SECTION("we can clump a table with two rows") {
+    mtxi::index_table table{{0, 0, 0}, {0, 0, 0}};
+    REQUIRE(!compute_clumped_output_table(table_p, output_clumps, table.cheader(), 1, 2));
+  }
+
+  SECTION("we can clump a table with two rows that result in two clumps") {
+    mtxi::index_table table{{0, 0, 0, 1}, {1, 0, 0}};
+    REQUIRE(compute_clumped_output_table(table_p, output_clumps, table.cheader(), 2, 2));
+    REQUIRE(table_p == mtxi::index_table{{0, 0, 1}, {1, 0, 0}});
+    REQUIRE(output_clumps == std::vector<uint64_t>{0, 1});
+  }
+
+  SECTION("we clump a table with multiple output clumps") {
+    mtxi::index_table table{
+        {0, 0, 0, 2, 3, 4, 5, 6}, // 0
+        {1, 0, 0, 1, 2, 4},       // 1
+        {2, 0, 0, 3, 4, 5, 6, 7}, // 2
+        {3, 0, 1, 2, 3, 4, 6, 7}, // 3
+    };
+    REQUIRE(compute_clumped_output_table(table_p, output_clumps, table.cheader(), 8, 4));
+    mtxi::index_table expected_table{
+        {0, 0, 0, 2, 4}, // 0
+        {1, 0, 3, 5, 6}, // 1
+        {2, 0, 1},       // 2
+        {3, 0, 0},       // 3
+        {4, 0, 4, 7},    // 4
+        {5, 0, 2, 3, 6}, // 5
+    };
+    REQUIRE(table_p == expected_table);
+    REQUIRE(output_clumps == std::vector<uint64_t>{1, 2, 6, 7, 8, 9});
+  }
+}
+
+TEST_CASE("we can rewrite the multiproduct table after clumping the outputs") {
+  SECTION("we handle the case of a single clump") {
+    mtxi::index_table table{{0, 0, 0}};
+    std::vector<size_t> clumps = {0};
+    rewrite_multiproducts_with_output_clumps(table.header(), clumps, 2);
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}});
+  }
+
+  SECTION("we handle a single clump with two outputs") {
+    mtxi::index_table table{{0, 0, 0}, {1, 0, 1}};
+    std::vector<size_t> clumps = {1};
+    rewrite_multiproducts_with_output_clumps(table.header(), clumps, 2);
+    REQUIRE(table == mtxi::index_table{{0, 0, 0}, {1, 0, 0}});
+  }
+
+  SECTION("we handle multiple outputs with multiple clumps") {
+    mtxi::index_table table{{0, 0, 0, 1}, {1, 0, 1, 3}, {2, 0, 2, 3, 5}, {3, 1, 0, 0, 1, 4}};
+    std::vector<size_t> clumps = {1, 2, 6, 7, 8, 9};
+    rewrite_multiproducts_with_output_clumps(table.header(), clumps, 4);
+    mtxi::index_table expected_table{
+        {0, 0, 0, 1},       // 0
+        {1, 0, 0, 2},       // 1
+        {2, 0, 1, 3, 4},    // 2
+        {3, 1, 0, 2, 4, 5}, // 3
+    };
+    REQUIRE(table == expected_table);
+  }
+}

--- a/sxt/multiexp/pippenger_multiprod/driver.cc
+++ b/sxt/multiexp/pippenger_multiprod/driver.cc
@@ -1,0 +1,32 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/driver.h"
+
+#include "sxt/base/container/span_void.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// compute_naive_multiproduct
+//--------------------------------------------------------------------------------------------------
+void driver::compute_naive_multiproduct(basct::span_void inout,
+                                        basct::span<basct::span<uint64_t>> products,
+                                        size_t num_inactive_inputs) const noexcept {
+  this->compute_naive_multiproduct(
+      inout, {reinterpret_cast<basct::cspan<uint64_t>*>(products.data()), products.size()},
+      num_inactive_inputs);
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/driver.h
+++ b/sxt/multiexp/pippenger_multiprod/driver.h
@@ -1,0 +1,56 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::basct {
+class span_void;
+}
+namespace sxt::mtxi {
+struct clump2_descriptor;
+}
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// driver
+//--------------------------------------------------------------------------------------------------
+class driver {
+public:
+  virtual ~driver() noexcept = default;
+
+  virtual void apply_partition_operation(basct::span_void inout,
+                                         basct::cspan<uint64_t> partition_markers,
+                                         size_t partition_size) const noexcept = 0;
+
+  virtual void apply_clump2_operation(basct::span_void inout, basct::cspan<uint64_t> markers,
+                                      const mtxi::clump2_descriptor& descriptor) const noexcept = 0;
+
+  virtual void compute_naive_multiproduct(basct::span_void inout,
+                                          basct::cspan<basct::cspan<uint64_t>> products,
+                                          size_t num_inactive_inputs) const noexcept = 0;
+
+  void compute_naive_multiproduct(basct::span_void inout,
+                                  basct::span<basct::span<uint64_t>> products,
+                                  size_t num_inactive_inputs) const noexcept;
+
+  virtual void permute_inputs(basct::span_void inout,
+                              basct::cspan<uint64_t> permutation) const noexcept = 0;
+};
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/multiproduct.cc
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct.cc
@@ -1,0 +1,109 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/multiproduct.h"
+
+#include <cstdlib>
+#include <limits>
+#include <vector>
+
+#include "sxt/base/container/span_void.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/iterator/counting_iterator.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/pippenger_multiprod/clump_inputs.h"
+#include "sxt/multiexp/pippenger_multiprod/clump_outputs.h"
+#include "sxt/multiexp/pippenger_multiprod/driver.h"
+#include "sxt/multiexp/pippenger_multiprod/multiproduct_params.h"
+#include "sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.h"
+#include "sxt/multiexp/pippenger_multiprod/partition_inputs.h"
+#include "sxt/multiexp/pippenger_multiprod/product_table_normalization.h"
+#include "sxt/multiexp/pippenger_multiprod/prune.h"
+#include "sxt/multiexp/pippenger_multiprod/reduction_stats.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// prune_and_permute_products
+//--------------------------------------------------------------------------------------------------
+static void prune_and_permute_products(basct::span_void inout,
+                                       basct::span<basct::span<uint64_t>> products,
+                                       size_t& num_inactive_outputs, size_t& num_inactive_inputs,
+                                       const driver& drv, size_t num_active_inputs) noexcept {
+  std::vector<uint64_t> permutation{basit::counting_iterator<uint64_t>{0},
+                                    basit::counting_iterator<uint64_t>{num_active_inputs}};
+  prune_rows(products, permutation, num_inactive_outputs, num_inactive_inputs);
+  drv.permute_inputs(inout, permutation);
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+void compute_multiproduct(basct::span_void inout, basct::span<basct::span<uint64_t>> products,
+                          const driver& drv, size_t num_inputs) noexcept {
+  size_t num_inactive_outputs = 0;
+  size_t num_inactive_inputs = 0;
+  prune_and_permute_products(inout, products, num_inactive_outputs, num_inactive_inputs, drv,
+                             num_inputs);
+  multiproduct_params params;
+  compute_multiproduct_params(params, products.size() - num_inactive_outputs,
+                              num_inputs - num_inactive_inputs);
+  if (params.partition_size > 0) {
+    reduction_stats stats;
+    auto num_inactive_inputs_p = num_inactive_inputs;
+    partition_inputs(inout.subspan(num_inactive_inputs), stats, products, num_inactive_outputs,
+                     num_inactive_inputs_p, drv, params.partition_size);
+    auto num_active_inputs = stats.num_terms - (num_inactive_inputs_p - num_inactive_inputs);
+    num_inactive_inputs = num_inactive_inputs_p;
+    prune_and_permute_products(inout.subspan(num_inactive_inputs), products, num_inactive_outputs,
+                               num_inactive_inputs, drv, num_active_inputs);
+  }
+  while (num_inactive_outputs < products.size()) {
+    reduction_stats stats;
+    size_t num_inactive_inputs_p = num_inactive_inputs;
+    clump_inputs(inout.subspan(num_inactive_inputs), stats, products, num_inactive_outputs,
+                 num_inactive_inputs_p, drv, params.input_clump_size);
+    if (stats.prev_num_terms == stats.num_terms) {
+      break;
+    }
+    auto num_active_inputs = stats.num_terms - (num_inactive_inputs_p - num_inactive_inputs);
+    num_inactive_inputs = num_inactive_inputs_p;
+
+    mtxi::index_table clumped_output_table;
+    std::vector<uint64_t> output_clumps;
+    if (!compute_clumped_output_table(clumped_output_table, output_clumps,
+                                      products.subspan(num_inactive_outputs), num_active_inputs,
+                                      params.output_clump_size)) {
+      break;
+    }
+    compute_multiproduct(inout.subspan(num_inactive_inputs), clumped_output_table.header(), drv,
+                         num_active_inputs);
+    rewrite_multiproducts_with_output_clumps(products.subspan(num_inactive_outputs), output_clumps,
+                                             params.output_clump_size);
+    num_active_inputs = output_clumps.size();
+    prune_and_permute_products(inout.subspan(num_inactive_inputs), products, num_inactive_outputs,
+                               num_inactive_inputs, drv, num_active_inputs);
+  }
+
+  drv.compute_naive_multiproduct(inout, products, num_inactive_inputs);
+}
+
+void compute_multiproduct(basct::span_void inout, mtxi::index_table& products, const driver& drv,
+                          size_t num_inputs) noexcept {
+  SXT_DEBUG_ASSERT(inout.size() >= num_inputs && inout.size() >= products.num_rows());
+  normalize_product_table(products, inout.size());
+  compute_multiproduct(inout, products.header(), drv, num_inputs);
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/multiproduct.h
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct.h
@@ -1,0 +1,43 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::basct {
+class span_void;
+}
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxpmp {
+class driver;
+struct multiproduct_params;
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct
+//--------------------------------------------------------------------------------------------------
+void compute_multiproduct(basct::span_void inout, basct::span<basct::span<uint64_t>> products,
+                          const driver& drv, size_t num_inputs) noexcept;
+
+void compute_multiproduct(basct::span_void inout, mtxi::index_table& products, const driver& drv,
+                          size_t num_inputs) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/multiproduct.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct.t.cc
@@ -1,0 +1,170 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/multiproduct.h"
+
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/pippenger_multiprod/multiproduct_params.h"
+#include "sxt/multiexp/pippenger_multiprod/test_driver.h"
+#include "sxt/multiexp/random/int_generation.h"
+#include "sxt/multiexp/random/random_multiproduct_descriptor.h"
+#include "sxt/multiexp/random/random_multiproduct_generation.h"
+#include "sxt/multiexp/test/add_ints.h"
+
+using namespace sxt;
+using namespace sxt::mtxpmp;
+
+static void verify_random_example(std::mt19937& rng,
+                                  const mtxrn::random_multiproduct_descriptor& descriptor) {
+  test_driver drv;
+  mtxi::index_table products;
+  size_t num_inputs;
+  size_t num_entries;
+  mtxrn::generate_random_multiproduct(products, num_inputs, num_entries, rng, descriptor);
+  memmg::managed_array<uint64_t> inout(num_entries);
+  mtxrn::generate_uint64s(basct::span<uint64_t>{inout.data(), num_inputs}, rng);
+  memmg::managed_array<uint64_t> expected_result(products.num_rows());
+  mtxtst::add_ints(expected_result, products.cheader(), inout);
+  compute_multiproduct(inout, products, drv, num_inputs);
+  for (size_t index = 0; index < products.num_rows(); ++index) {
+    REQUIRE(inout[index] == expected_result[index]);
+  }
+}
+
+TEST_CASE("we can compute multiproducts") {
+  test_driver drv;
+
+  SECTION("we handle the empty case") {
+    memmg::managed_array<uint64_t> inout;
+    mtxi::index_table products;
+    compute_multiproduct(inout, products, drv, 0);
+    REQUIRE(inout.empty());
+  }
+
+  SECTION("we handle a multiproduct with a single term") {
+    memmg::managed_array<uint64_t> inout = {22};
+    mtxi::index_table products{{0}};
+    compute_multiproduct(inout, products, drv, 1);
+    memmg::managed_array<uint64_t> expected_result = {22};
+    REQUIRE(inout == expected_result);
+  }
+
+  SECTION("we handle a single output with multiple terms") {
+    memmg::managed_array<uint64_t> inout = {22, 3};
+    mtxi::index_table products{{0, 1}};
+    compute_multiproduct(inout, products, drv, 2);
+    REQUIRE(inout[0] == 25);
+  }
+
+  SECTION("we handle a multi-product with two outputs") {
+    memmg::managed_array<uint64_t> inout = {22, 3, 10, 999, 999};
+    mtxi::index_table products{{0, 1, 2}, {0, 2}};
+    compute_multiproduct(inout, products, drv, 3);
+    REQUIRE(inout[0] == 35);
+    REQUIRE(inout[1] == 32);
+  }
+
+  SECTION("we can handle random multiproducts with only two rows and few entries") {
+    std::mt19937 rng{0};
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 4,
+        .min_num_sequences = 2,
+        .max_num_sequences = 2,
+        .max_num_inputs = 8,
+    };
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with two rows and many entries") {
+    std::mt19937 rng{0};
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 20,
+        .min_num_sequences = 2,
+        .max_num_sequences = 2,
+        .max_num_inputs = 20,
+    };
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with three rows") {
+    std::mt19937 rng{0};
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 20,
+        .min_num_sequences = 3,
+        .max_num_sequences = 3,
+        .max_num_inputs = 20,
+    };
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with multiple rows") {
+    std::mt19937 rng{0};
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 20,
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .max_num_inputs = 20,
+    };
+    for (int i = 0; i < 100; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with many rows") {
+    std::mt19937 rng{0};
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1,
+        .max_sequence_length = 100,
+        .min_num_sequences = 100,
+        .max_num_sequences = 1000,
+        .max_num_inputs = 200,
+    };
+    for (int i = 0; i < 10; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+
+  SECTION("we handle random multiproducts with many inputs") {
+    std::mt19937 rng{0};
+    mtxrn::random_multiproduct_descriptor random_descriptor{
+        .min_sequence_length = 1000,
+        .max_sequence_length = 2000,
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .max_num_inputs = 4000,
+    };
+    for (int i = 0; i < 10; ++i) {
+      verify_random_example(rng, random_descriptor);
+    }
+  }
+}

--- a/sxt/multiexp/pippenger_multiprod/multiproduct_params.cc
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct_params.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/multiproduct_params.h"

--- a/sxt/multiexp/pippenger_multiprod/multiproduct_params.h
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct_params.h
@@ -1,0 +1,30 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// multiproduct_params
+//--------------------------------------------------------------------------------------------------
+struct multiproduct_params {
+  size_t partition_size;
+  size_t input_clump_size;
+  size_t output_clump_size;
+};
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.cc
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.cc
@@ -1,0 +1,41 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.h"
+
+#include <cmath>
+
+#include "sxt/multiexp/pippenger_multiprod/multiproduct_params.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct_params
+//--------------------------------------------------------------------------------------------------
+void compute_multiproduct_params(multiproduct_params& params, size_t num_outputs,
+                                 size_t num_inputs) noexcept {
+  if (num_inputs == 0) {
+    params = {};
+    return;
+  }
+  params.partition_size = static_cast<size_t>(std::ceil(std::log2(num_outputs * num_inputs)));
+  if (params.partition_size <= 3 || params.partition_size >= num_inputs / 2) {
+    params.partition_size = 0;
+  }
+  auto clump_size = std::ceil(num_inputs / std::log2(num_inputs + 1));
+  params.input_clump_size = clump_size;
+  params.output_clump_size = clump_size;
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.h
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace sxt::mtxpmp {
+struct multiproduct_params;
+
+//--------------------------------------------------------------------------------------------------
+// compute_multiproduct_params
+//--------------------------------------------------------------------------------------------------
+void compute_multiproduct_params(multiproduct_params& params, size_t num_outputs,
+                                 size_t num_inputs) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.t.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/multiproduct_params_computation.h"

--- a/sxt/multiexp/pippenger_multiprod/partition_inputs.cc
+++ b/sxt/multiexp/pippenger_multiprod/partition_inputs.cc
@@ -1,0 +1,56 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/partition_inputs.h"
+
+#include <vector>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/container/span_void.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/index/marker_transformation.h"
+#include "sxt/multiexp/index/partition_marker_utility.h"
+#include "sxt/multiexp/index/reindex.h"
+#include "sxt/multiexp/pippenger_multiprod/active_offset.h"
+#include "sxt/multiexp/pippenger_multiprod/driver.h"
+#include "sxt/multiexp/pippenger_multiprod/prune.h"
+#include "sxt/multiexp/pippenger_multiprod/reduction_stats.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// partition_inputs
+//--------------------------------------------------------------------------------------------------
+void partition_inputs(basct::span_void inout, reduction_stats& stats,
+                      basct::span<basct::span<uint64_t>> products, size_t& num_inactive_outputs,
+                      size_t& num_inactive_inputs, const driver& drv,
+                      size_t partition_size) noexcept {
+  auto num_entries_p = mtxi::apply_marker_transformation(
+      products.subspan(num_inactive_outputs),
+      [partition_size](basct::span<uint64_t>& indexes) noexcept {
+        return mtxi::consume_partition_marker(indexes, partition_size);
+      },
+      compute_active_offset);
+  stats.prev_num_terms = num_entries_p;
+
+  std::vector<uint64_t> markers(num_entries_p);
+  basct::span<uint64_t> markers_view{markers.data(), num_entries_p};
+  mtxi::reindex_rows(products.subspan(num_inactive_outputs), markers_view, compute_active_offset);
+  markers.resize(markers_view.size());
+  stats.num_terms = markers.size();
+
+  drv.apply_partition_operation(inout, markers, partition_size);
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/partition_inputs.h
+++ b/sxt/multiexp/pippenger_multiprod/partition_inputs.h
@@ -1,0 +1,42 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::basct {
+class span_void;
+}
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxpmp {
+class driver;
+struct reduction_stats;
+
+//--------------------------------------------------------------------------------------------------
+// partition_inputs
+//--------------------------------------------------------------------------------------------------
+void partition_inputs(basct::span_void inout, reduction_stats& stats,
+                      basct::span<basct::span<uint64_t>> products, size_t& num_inactive_outputs,
+                      size_t& num_inactive_inputs, const driver& drv,
+                      size_t partition_size) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/partition_inputs.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/partition_inputs.t.cc
@@ -1,0 +1,121 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/partition_inputs.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/pippenger_multiprod/reduction_stats.h"
+#include "sxt/multiexp/pippenger_multiprod/test_driver.h"
+
+using namespace sxt;
+using namespace sxt::mtxpmp;
+
+TEST_CASE("we can partition the inputs of a multiproduct") {
+  test_driver drv;
+  reduction_stats stats;
+
+  SECTION("partitioning a single entry product does nothing") {
+    memmg::managed_array<uint64_t> inputs{10};
+    mtxi::index_table products{{0, 0, 0}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    partition_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs,
+                     drv, 2);
+
+    REQUIRE(stats.prev_num_terms == 1);
+    REQUIRE(stats.num_terms == 1);
+
+    memmg::managed_array<uint64_t> expected_inputs{10};
+    REQUIRE(inputs == expected_inputs);
+
+    mtxi::index_table expected_products{{0, 0, 0}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("partitioning a product with two entries adds them together") {
+    memmg::managed_array<uint64_t> inputs{10, 5};
+    mtxi::index_table products{{0, 0, 0, 1}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    partition_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs,
+                     drv, 2);
+
+    REQUIRE(stats.prev_num_terms == 1);
+    REQUIRE(stats.num_terms == 1);
+
+    REQUIRE(inputs[0] == 15);
+
+    mtxi::index_table expected_products{{0, 0, 0}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("we can partition a table with two rows and three elements") {
+    memmg::managed_array<uint64_t> inputs{10, 5};
+    mtxi::index_table products{{0, 0, 0, 1}, {1, 0, 1}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    partition_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs,
+                     drv, 2);
+
+    REQUIRE(stats.prev_num_terms == 2);
+    REQUIRE(stats.num_terms == 2);
+
+    REQUIRE(inputs[0] == 5);
+    REQUIRE(inputs[1] == 15);
+
+    mtxi::index_table expected_products{{0, 0, 1}, {1, 0, 0}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("identical groups of elements within a partition across rows are "
+          "reindexed to the same input") {
+    memmg::managed_array<uint64_t> inputs{10, 5, 20};
+    mtxi::index_table products{{0, 0, 0, 1}, {1, 0, 0, 1, 2}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    partition_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs,
+                     drv, 2);
+
+    REQUIRE(stats.prev_num_terms == 3);
+    REQUIRE(stats.num_terms == 2);
+
+    REQUIRE(inputs[0] == 15);
+    REQUIRE(inputs[1] == 20);
+
+    mtxi::index_table expected_products{{0, 0, 0}, {1, 0, 0, 1}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("we can partition with size 3") {
+    memmg::managed_array<uint64_t> inputs{10, 5, 6, 20};
+    mtxi::index_table products{{0, 0, 0, 1}, {1, 0, 1, 3}, {2, 0, 2}};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    partition_inputs(inputs, stats, products.header(), num_inactive_outputs, num_inactive_inputs,
+                     drv, 3);
+
+    REQUIRE(stats.prev_num_terms == 4);
+    REQUIRE(stats.num_terms == 4);
+
+    memmg::managed_array<uint64_t> expected_inputs{5, 15, 6, 20};
+    REQUIRE(inputs == expected_inputs);
+
+    mtxi::index_table expected_products{{0, 0, 1}, {1, 0, 0, 3}, {2, 0, 2}};
+    REQUIRE(products == expected_products);
+  }
+}

--- a/sxt/multiexp/pippenger_multiprod/product_table_normalization.cc
+++ b/sxt/multiexp/pippenger_multiprod/product_table_normalization.cc
@@ -1,0 +1,42 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/product_table_normalization.h"
+
+#include <algorithm>
+
+#include "sxt/multiexp/index/index_table.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// normalize_product_table
+//--------------------------------------------------------------------------------------------------
+void normalize_product_table(mtxi::index_table& products, size_t num_entries) noexcept {
+  size_t num_entries_p = num_entries + products.num_rows() * 2;
+  mtxi::index_table products_p{products.num_rows(), num_entries_p};
+  auto entry_data = products_p.entry_data();
+  auto rows = products.cheader();
+  auto rows_p = products_p.header();
+  for (size_t row_index = 0; row_index < rows_p.size(); ++row_index) {
+    auto row = rows[row_index];
+    rows_p[row_index] = {entry_data, row.size() + 2};
+    *entry_data++ = row_index;
+    *entry_data++ = 0;
+    entry_data = std::copy(row.begin(), row.end(), entry_data);
+  }
+  products = std::move(products_p);
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/product_table_normalization.h
+++ b/sxt/multiexp/pippenger_multiprod/product_table_normalization.h
@@ -1,0 +1,30 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// normalize_product_table
+//--------------------------------------------------------------------------------------------------
+void normalize_product_table(mtxi::index_table& products, size_t num_entries) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/product_table_normalization.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/product_table_normalization.t.cc
@@ -1,0 +1,52 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/product_table_normalization.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/index_table.h"
+
+using namespace sxt;
+using namespace sxt::mtxpmp;
+
+TEST_CASE("we can convert a table of products into normalized form") {
+  SECTION("we can normalize an empty table") {
+    mtxi::index_table products;
+    normalize_product_table(products, 0);
+    REQUIRE(products.empty());
+  }
+
+  SECTION("we can normalize a table with a single element") {
+    mtxi::index_table products{{0}};
+    normalize_product_table(products, 1);
+    mtxi::index_table expected_products{{0, 0, 0}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("we can normalize a table with a single row with multiple entries") {
+    mtxi::index_table products{{0, 1, 2}};
+    normalize_product_table(products, 3);
+    mtxi::index_table expected_products{{0, 0, 0, 1, 2}};
+    REQUIRE(products == expected_products);
+  }
+
+  SECTION("we can normalize a table with multiple rows with multiple entries") {
+    mtxi::index_table products{{0, 1, 2}, {1, 2}};
+    normalize_product_table(products, 5);
+    mtxi::index_table expected_products{{0, 0, 0, 1, 2}, {1, 0, 1, 2}};
+    REQUIRE(products == expected_products);
+  }
+}

--- a/sxt/multiexp/pippenger_multiprod/prune.cc
+++ b/sxt/multiexp/pippenger_multiprod/prune.cc
@@ -1,0 +1,103 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/prune.h"
+
+#include <algorithm>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+#include "sxt/base/error/assert.h"
+#include "sxt/base/iterator/counting_iterator.h"
+#include "sxt/multiexp/pippenger_multiprod/active_count.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// prune_rows
+//--------------------------------------------------------------------------------------------------
+void prune_rows(basct::span<basct::span<uint64_t>> rows, std::vector<uint64_t>& markers,
+                size_t& num_inactive_outputs, size_t& num_inactive_inputs) noexcept {
+  // get the count for each entry
+  std::vector<size_t> v1(markers.size());
+  std::vector<size_t> max_active_counts(markers.size());
+  for (size_t row_index = num_inactive_outputs; row_index < rows.size(); ++row_index) {
+    auto& row = rows[row_index];
+    auto num_inactive_entries = row[1];
+    auto num_active_entries = row.size() - 2 - num_inactive_entries;
+    SXT_DEBUG_ASSERT(num_active_entries > 0);
+    for (size_t entry_index = 2 + num_inactive_entries; entry_index < row.size(); ++entry_index) {
+      auto entry = row[entry_index];
+      ++v1[entry];
+      SXT_DEBUG_ASSERT(entry < max_active_counts.size());
+      max_active_counts[entry] = std::max(max_active_counts[entry], num_active_entries);
+    }
+  }
+
+  // partition the entries to separate out the isolated ones
+  std::vector<uint64_t> v2(markers.size());
+  auto [sep, sep_p] = std::partition_copy(basit::counting_iterator<uint64_t>{0},
+                                          basit::counting_iterator<uint64_t>{markers.size()},
+                                          v2.begin(), v2.rbegin(), [&](size_t index) noexcept {
+                                            SXT_DEBUG_ASSERT(v1[index] > 0);
+                                            return v1[index] == 1 || max_active_counts[index] == 1;
+                                          });
+  auto deactivation_count = static_cast<size_t>(std::distance(v2.begin(), sep));
+  if (deactivation_count == 0) {
+    return;
+  }
+  size_t counter = 0;
+  for (auto iter = v2.begin(); iter != sep; ++iter) {
+    v1[*iter] = markers.size() + num_inactive_inputs + counter++;
+  }
+  counter = 0;
+  for (auto iter = v2.rbegin(); iter != sep_p; ++iter) {
+    v1[*iter] = counter++;
+  }
+
+  // reindex and update the inactive counts
+  for (size_t row_index = num_inactive_outputs; row_index < rows.size(); ++row_index) {
+    auto& row = rows[row_index];
+    auto& num_inactive_entries = row[1];
+    std::tie(sep, sep_p) = std::partition_copy(
+        row.begin() + 2 + num_inactive_entries, row.end(), v2.begin(), v2.rbegin(),
+        [&](uint64_t index) noexcept { return v1[index] >= markers.size(); });
+    for (auto iter = v2.begin(); iter != sep; ++iter) {
+      row[2 + num_inactive_entries++] = v1[*iter] - markers.size();
+    }
+    auto active_iter = row.data() + 2 + num_inactive_entries;
+    for (auto iter = v2.rbegin(); iter != sep_p; ++iter) {
+      *active_iter++ = v1[*iter];
+    }
+    if (2 + num_inactive_entries == row.size()) {
+      std::swap(row, rows[num_inactive_outputs]);
+      ++num_inactive_outputs;
+    }
+  }
+
+  // update the markers
+  for (size_t index = 0; index < markers.size(); ++index) {
+    auto index_p = v1[index];
+    if (index_p >= markers.size()) {
+      v2[index_p - markers.size() - num_inactive_inputs] = markers[index];
+    } else {
+      v2[index_p + deactivation_count] = markers[index];
+    }
+  }
+  markers.swap(v2);
+  num_inactive_inputs += deactivation_count;
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/prune.h
+++ b/sxt/multiexp/pippenger_multiprod/prune.h
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// prune_rows
+//--------------------------------------------------------------------------------------------------
+void prune_rows(basct::span<basct::span<uint64_t>> rows, std::vector<uint64_t>& markers,
+                size_t& num_inactive_outputs, size_t& num_inactive_inputs) noexcept;
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/prune.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/prune.t.cc
@@ -1,0 +1,127 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/prune.h"
+
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/index/index_table.h"
+
+using namespace sxt;
+using namespace sxt::mtxpmp;
+
+TEST_CASE("we can prune the multi-product table to deactive inputs and outputs") {
+  SECTION("we handle the empty case") {
+    mtxi::index_table table;
+    std::vector<uint64_t> markers;
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    prune_rows(table.header(), markers, num_inactive_outputs, num_inactive_inputs);
+
+    mtxi::index_table expected_table;
+    REQUIRE(table == expected_table);
+    REQUIRE(num_inactive_outputs == 0);
+    REQUIRE(num_inactive_inputs == 0);
+  }
+
+  SECTION("we handle the case when there are no active outputs") {
+    mtxi::index_table table{{0, 1, 0}};
+    std::vector<uint64_t> markers;
+    size_t num_inactive_outputs = 1;
+    size_t num_inactive_inputs = 1;
+    prune_rows(table.header(), markers, num_inactive_outputs, num_inactive_inputs);
+
+    mtxi::index_table expected_table{{0, 1, 0}};
+    REQUIRE(table == expected_table);
+    REQUIRE(num_inactive_outputs == 1);
+    REQUIRE(num_inactive_inputs == 1);
+  }
+
+  SECTION("we handle the case of one output and one deactivation") {
+    mtxi::index_table table{{0, 0, 0}};
+    std::vector<uint64_t> markers = {99};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    prune_rows(table.header(), markers, num_inactive_outputs, num_inactive_inputs);
+
+    mtxi::index_table expected_table{{0, 1, 0}};
+    REQUIRE(table == expected_table);
+    REQUIRE(num_inactive_outputs == 1);
+    REQUIRE(num_inactive_inputs == 1);
+    std::vector<uint64_t> expected_markers = {99};
+    REQUIRE(markers == expected_markers);
+  }
+
+  SECTION("we handle the case of two outputs, one deactivation, and one "
+          "non-deactivation") {
+    mtxi::index_table table{{0, 0, 0, 1}, {1, 0, 0}};
+    std::vector<uint64_t> markers = {99, 101};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    prune_rows(table.header(), markers, num_inactive_outputs, num_inactive_inputs);
+
+    mtxi::index_table expected_table{{0, 1, 0, 0}, {1, 0, 0}};
+    REQUIRE(table == expected_table);
+    REQUIRE(num_inactive_outputs == 0);
+    REQUIRE(num_inactive_inputs == 1);
+    std::vector<uint64_t> expected_markers = {101, 99};
+    REQUIRE(markers == expected_markers);
+  }
+
+  SECTION("we can deactivate many entries") {
+    mtxi::index_table table{{0, 1, 0, 0, 1, 2, 3}, {1, 0, 1}};
+    std::vector<uint64_t> markers = {99, 100, 101, 102};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 1;
+    prune_rows(table.header(), markers, num_inactive_outputs, num_inactive_inputs);
+
+    mtxi::index_table expected_table{{0, 4, 0, 1, 2, 3, 0}, {1, 0, 0}};
+    REQUIRE(table == expected_table);
+    REQUIRE(num_inactive_outputs == 0);
+    REQUIRE(num_inactive_inputs == 4);
+    std::vector<uint64_t> expected_markers = {99, 101, 102, 100};
+    REQUIRE(markers == expected_markers);
+  }
+
+  SECTION("we deactive entries that are only in rows with a single active entry") {
+    mtxi::index_table table{{0, 1, 0, 0}, {1, 0, 0}};
+    std::vector<uint64_t> markers = {99};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 1;
+    prune_rows(table.header(), markers, num_inactive_outputs, num_inactive_inputs);
+
+    mtxi::index_table expected_table{{0, 2, 0, 1}, {1, 1, 1}};
+    REQUIRE(table == expected_table);
+    REQUIRE(num_inactive_outputs == 2);
+    REQUIRE(num_inactive_inputs == 2);
+    std::vector<uint64_t> expected_markers = {99};
+    REQUIRE(markers == expected_markers);
+  }
+
+  SECTION("we can handle multiple active entries") {
+    mtxi::index_table table{{0, 0, 0, 1, 2}, {1, 0, 0, 2}};
+    std::vector<uint64_t> markers = {101, 102, 103};
+    size_t num_inactive_outputs = 0;
+    size_t num_inactive_inputs = 0;
+    prune_rows(table.header(), markers, num_inactive_outputs, num_inactive_inputs);
+
+    mtxi::index_table expected_table{{0, 1, 0, 0, 1}, {1, 0, 0, 1}};
+    REQUIRE(table == expected_table);
+    std::vector<uint64_t> expected_markers = {102, 101, 103};
+    REQUIRE(markers == expected_markers);
+  }
+}

--- a/sxt/multiexp/pippenger_multiprod/reduction_stats.cc
+++ b/sxt/multiexp/pippenger_multiprod/reduction_stats.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/reduction_stats.h"

--- a/sxt/multiexp/pippenger_multiprod/reduction_stats.h
+++ b/sxt/multiexp/pippenger_multiprod/reduction_stats.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// reduction_stats
+//--------------------------------------------------------------------------------------------------
+struct reduction_stats {
+  size_t prev_num_terms;
+  size_t num_terms;
+};
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/test_driver.cc
+++ b/sxt/multiexp/pippenger_multiprod/test_driver.cc
@@ -1,0 +1,134 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/test_driver.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+
+#include "sxt/base/bit/iteration.h"
+#include "sxt/base/container/span_void.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/error/panic.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/index/clump2_descriptor.h"
+#include "sxt/multiexp/index/clump2_marker_utility.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// apply_partition_operation
+//--------------------------------------------------------------------------------------------------
+void test_driver::apply_partition_operation(basct::span_void inout,
+                                            basct::cspan<uint64_t> partition_markers,
+                                            size_t partition_size) const noexcept {
+  auto num_inputs = inout.size();
+  auto num_inputs_p = partition_markers.size();
+
+  basct::span<uint64_t> inputs{static_cast<uint64_t*>(inout.data()), num_inputs};
+  memmg::managed_array<uint64_t> inputs_p(num_inputs_p);
+
+  for (size_t marker_index = 0; marker_index < num_inputs_p; ++marker_index) {
+    auto marker = partition_markers[marker_index];
+    auto partition_index = marker >> partition_size;
+    auto bitset = marker ^ (partition_index << partition_size);
+    SXT_DEBUG_ASSERT(bitset != 0);
+    size_t partition_first = partition_index * partition_size;
+    uint64_t reduction = 0;
+    while (bitset != 0) {
+      auto index = basbt::consume_next_bit(bitset);
+      reduction += inputs[partition_first + index];
+    }
+    inputs_p[marker_index] = reduction;
+  }
+
+  std::copy_n(inputs_p.data(), inputs_p.size(), inputs.data());
+}
+
+//--------------------------------------------------------------------------------------------------
+// apply_clump2_operation
+//--------------------------------------------------------------------------------------------------
+void test_driver::apply_clump2_operation(basct::span_void inout, basct::cspan<uint64_t> markers,
+                                         const mtxi::clump2_descriptor& descriptor) const noexcept {
+  auto num_inputs = inout.size();
+  auto num_inputs_p = markers.size();
+
+  basct::span<uint64_t> inputs{static_cast<uint64_t*>(inout.data()), num_inputs};
+  memmg::managed_array<uint64_t> inputs_p(num_inputs_p);
+
+  for (size_t marker_index = 0; marker_index < num_inputs_p; ++marker_index) {
+    auto marker = markers[marker_index];
+    uint64_t clump_index, index1, index2;
+    mtxi::unpack_clump2_marker(clump_index, index1, index2, descriptor, marker);
+    auto clump_first = descriptor.size * clump_index;
+    auto reduction = inputs[clump_first + index1];
+    SXT_DEBUG_ASSERT(index1 <= index2);
+    if (index1 != index2) {
+      reduction += inputs[clump_first + index2];
+    }
+    inputs_p[marker_index] = reduction;
+  }
+
+  std::copy_n(inputs_p.data(), num_inputs_p, inputs.data());
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_naive_multiproduct
+//--------------------------------------------------------------------------------------------------
+void test_driver::compute_naive_multiproduct(basct::span_void inout,
+                                             basct::cspan<basct::cspan<uint64_t>> products,
+                                             size_t num_inactive_inputs) const noexcept {
+  basct::span<uint64_t> inputs{static_cast<uint64_t*>(inout.data()), inout.size()};
+  memmg::managed_array<uint64_t> outputs(products.size());
+  for (auto row : products) {
+    SXT_DEBUG_ASSERT(row.size() >= 2 && row.size() >= 2 + row[1]);
+    auto& output = outputs[row[0]];
+    output = 0;
+    auto num_inactive_entries = row[1];
+    // add inactive entries
+    for (size_t index = 2; index < 2 + num_inactive_entries; ++index) {
+      output += inputs[row[index]];
+    }
+    // add active entries
+    for (size_t index = 2 + num_inactive_entries; index < row.size(); ++index) {
+      output += inputs[num_inactive_inputs + row[index]];
+    }
+  }
+  std::copy_n(outputs.data(), outputs.size(), inputs.data());
+}
+
+//--------------------------------------------------------------------------------------------------
+// permute_inputs
+//--------------------------------------------------------------------------------------------------
+void test_driver::permute_inputs(basct::span_void inout,
+                                 basct::cspan<uint64_t> permutation) const noexcept {
+  auto n = permutation.size();
+  if (n > inout.size()) {
+    baser::panic("n > inout.size()");
+  }
+  basct::span<uint64_t> inputs{static_cast<uint64_t*>(inout.data()), n};
+  memmg::managed_array<uint64_t> inputs_p(n);
+  for (size_t index = 0; index < n; ++index) {
+    auto index_p = permutation[index];
+    if (index_p >= n) {
+      baser::panic("index_p >= n");
+    }
+    inputs_p[index] = inputs[index_p];
+  }
+  std::copy_n(inputs_p.data(), n, inputs.data());
+}
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/test_driver.h
+++ b/sxt/multiexp/pippenger_multiprod/test_driver.h
@@ -1,0 +1,42 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/multiexp/pippenger_multiprod/driver.h"
+
+namespace sxt::mtxpmp {
+//--------------------------------------------------------------------------------------------------
+// test_driver
+//--------------------------------------------------------------------------------------------------
+class test_driver final : public driver {
+public:
+  void apply_partition_operation(basct::span_void inout, basct::cspan<uint64_t> partition_markers,
+                                 size_t partition_size) const noexcept override;
+
+  void apply_clump2_operation(basct::span_void inout, basct::cspan<uint64_t> markers,
+                              const mtxi::clump2_descriptor& descriptor) const noexcept override;
+
+  void compute_naive_multiproduct(basct::span_void inout,
+                                  basct::cspan<basct::cspan<uint64_t>> products,
+                                  size_t num_inactive_inputs) const noexcept override;
+
+  void permute_inputs(basct::span_void inout,
+                      basct::cspan<uint64_t> permutation) const noexcept override;
+
+private:
+};
+} // namespace sxt::mtxpmp

--- a/sxt/multiexp/pippenger_multiprod/test_driver.t.cc
+++ b/sxt/multiexp/pippenger_multiprod/test_driver.t.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger_multiprod/test_driver.h"

--- a/sxt/multiexp/random/BUILD
+++ b/sxt/multiexp/random/BUILD
@@ -1,0 +1,57 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "random_multiexponentiation_descriptor",
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "random_multiexponentiation_generation",
+    impl_deps = [
+        ":int_generation",
+        ":random_multiexponentiation_descriptor",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/base/error:assert",
+        "//sxt/base/memory:alloc_utility",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/ristretto/random:element",
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/memory:alloc",
+    ],
+)
+
+sxt_cc_component(
+    name = "random_multiproduct_descriptor",
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "random_multiproduct_generation",
+    impl_deps = [
+        ":random_multiproduct_descriptor",
+        "//sxt/multiexp/index:index_table",
+        "//sxt/multiexp/index:reindex",
+        "//sxt/memory/management:managed_array",
+        "//sxt/base/error:panic",
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "int_generation",
+    impl_deps = [],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)

--- a/sxt/multiexp/random/int_generation.cc
+++ b/sxt/multiexp/random/int_generation.cc
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/random/int_generation.h"
+
+namespace sxt::mtxrn {
+//--------------------------------------------------------------------------------------------------
+// generate_uint64s
+//--------------------------------------------------------------------------------------------------
+void generate_uint64s(basct::span<uint64_t> generators, std::mt19937& rng) noexcept {
+  std::uniform_int_distribution<uint64_t> generators_gen;
+
+  // populate the generators array
+  for (size_t i = 0; i < generators.size(); ++i) {
+    generators[i] = generators_gen(rng);
+  }
+}
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/random/int_generation.h
+++ b/sxt/multiexp/random/int_generation.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <random>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxrn {
+//--------------------------------------------------------------------------------------------------
+// generate_uint64s
+//--------------------------------------------------------------------------------------------------
+void generate_uint64s(basct::span<uint64_t> generators, std::mt19937& rng) noexcept;
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/random/random_multiexponentiation_descriptor.cc
+++ b/sxt/multiexp/random/random_multiexponentiation_descriptor.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/random/random_multiexponentiation_descriptor.h"

--- a/sxt/multiexp/random/random_multiexponentiation_descriptor.h
+++ b/sxt/multiexp/random/random_multiexponentiation_descriptor.h
@@ -1,0 +1,33 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace sxt::mtxrn {
+//--------------------------------------------------------------------------------------------------
+// random_multiexponentiation_descriptor
+//--------------------------------------------------------------------------------------------------
+struct random_multiexponentiation_descriptor {
+  size_t min_num_sequences = 1;
+  size_t max_num_sequences = 1;
+  size_t min_sequence_length = 1;
+  size_t max_sequence_length = 10;
+  size_t min_exponent_num_bytes = 1;
+  size_t max_exponent_num_bytes = 32;
+};
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/random/random_multiexponentiation_generation.cc
+++ b/sxt/multiexp/random/random_multiexponentiation_generation.cc
@@ -1,0 +1,95 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/random/random_multiexponentiation_generation.h"
+
+#include <algorithm>
+
+#include "sxt/base/error/assert.h"
+#include "sxt/base/memory/alloc_utility.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/random/int_generation.h"
+#include "sxt/multiexp/random/random_multiexponentiation_descriptor.h"
+#include "sxt/ristretto/random/element.h"
+
+namespace sxt::mtxrn {
+//--------------------------------------------------------------------------------------------------
+// generate_random_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+void generate_random_multiexponentiation(
+    uint64_t& num_inputs, basct::span<mtxb::exponent_sequence>& exponents, basm::alloc_t alloc,
+    std::mt19937& rng, const random_multiexponentiation_descriptor& descriptor) noexcept {
+  //clang-format off
+  SXT_RELEASE_ASSERT(descriptor.min_num_sequences <= descriptor.max_num_sequences &&
+                     descriptor.min_sequence_length <= descriptor.max_sequence_length &&
+                     descriptor.min_exponent_num_bytes <= descriptor.max_exponent_num_bytes &&
+                     descriptor.max_exponent_num_bytes <= 32);
+  //clang-format on
+  auto num_sequences = std::uniform_int_distribution<size_t>{descriptor.min_num_sequences,
+                                                             descriptor.max_num_sequences}(rng);
+  exponents = {
+      basm::allocate_array<mtxb::exponent_sequence>(alloc, num_sequences),
+      num_sequences,
+  };
+  num_inputs = 0;
+  for (size_t sequence_index = 0; sequence_index < num_sequences; ++sequence_index) {
+    std::uniform_int_distribution<uint8_t> data_gen(0, 255);
+    std::uniform_int_distribution<size_t> sequence_gen(descriptor.min_sequence_length,
+                                                       descriptor.max_sequence_length);
+    std::uniform_int_distribution<uint8_t> exponent_gen(descriptor.min_exponent_num_bytes,
+                                                        descriptor.max_exponent_num_bytes);
+    size_t sequence_length = sequence_gen(rng);
+    uint8_t exponent_length = exponent_gen(rng);
+    size_t sequence_total_num_bytes = sequence_length * exponent_length;
+    num_inputs = std::max(num_inputs, sequence_length);
+    auto exponent_array = alloc.allocate(sequence_total_num_bytes);
+    std::generate_n(exponent_array, sequence_total_num_bytes,
+                    [&]() noexcept { return static_cast<std::byte>(data_gen(rng)); });
+    exponents[sequence_index] = {
+        .element_nbytes = exponent_length,
+        .n = sequence_length,
+        .data = reinterpret_cast<const uint8_t*>(exponent_array),
+    };
+  }
+}
+
+void generate_random_multiexponentiation(
+    basct::span<uint64_t>& inputs, basct::span<mtxb::exponent_sequence>& exponents,
+    basm::alloc_t alloc, std::mt19937& rng,
+    const random_multiexponentiation_descriptor& descriptor) noexcept {
+  size_t num_inputs;
+  generate_random_multiexponentiation(num_inputs, exponents, alloc, rng, descriptor);
+  inputs = {
+      basm::allocate_array<uint64_t>(alloc, num_inputs),
+      num_inputs,
+  };
+  generate_uint64s(inputs, rng);
+}
+
+void generate_random_multiexponentiation(
+    basct::span<c21t::element_p3>& inputs, basct::span<mtxb::exponent_sequence>& exponents,
+    basm::alloc_t alloc, std::mt19937& rng,
+    const random_multiexponentiation_descriptor& descriptor) noexcept {
+  size_t num_inputs;
+  generate_random_multiexponentiation(num_inputs, exponents, alloc, rng, descriptor);
+  inputs = {
+      basm::allocate_array<c21t::element_p3>(alloc, num_inputs),
+      num_inputs,
+  };
+  rstrn::generate_random_elements(inputs, rng);
+}
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/random/random_multiexponentiation_generation.h
+++ b/sxt/multiexp/random/random_multiexponentiation_generation.h
@@ -1,0 +1,52 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <memory_resource>
+#include <random>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/memory/alloc.h"
+
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+namespace sxt::c21t {
+struct element_p3;
+}
+
+namespace sxt::mtxrn {
+struct random_multiexponentiation_descriptor;
+
+//--------------------------------------------------------------------------------------------------
+// generate_random_multiexponentiation
+//--------------------------------------------------------------------------------------------------
+void generate_random_multiexponentiation(
+    uint64_t& num_inputs, basct::span<mtxb::exponent_sequence>& exponents, basm::alloc_t alloc,
+    std::mt19937& rng, const random_multiexponentiation_descriptor& descriptor) noexcept;
+
+void generate_random_multiexponentiation(
+    basct::span<uint64_t>& inputs, basct::span<mtxb::exponent_sequence>& exponents,
+    basm::alloc_t alloc, std::mt19937& rng,
+    const random_multiexponentiation_descriptor& descriptor) noexcept;
+
+void generate_random_multiexponentiation(
+    basct::span<c21t::element_p3>& inputs, basct::span<mtxb::exponent_sequence>& exponents,
+    basm::alloc_t alloc, std::mt19937& rng,
+    const random_multiexponentiation_descriptor& descriptor) noexcept;
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/random/random_multiproduct_descriptor.cc
+++ b/sxt/multiexp/random/random_multiproduct_descriptor.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/random/random_multiproduct_descriptor.h"

--- a/sxt/multiexp/random/random_multiproduct_descriptor.h
+++ b/sxt/multiexp/random/random_multiproduct_descriptor.h
@@ -1,0 +1,32 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+
+namespace sxt::mtxrn {
+//--------------------------------------------------------------------------------------------------
+// random_multiproduct_descriptor
+//--------------------------------------------------------------------------------------------------
+struct random_multiproduct_descriptor {
+  size_t min_sequence_length = 1;
+  size_t max_sequence_length = 10;
+  size_t min_num_sequences = 2;
+  size_t max_num_sequences = 10;
+  size_t max_num_inputs = 10;
+};
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/random/random_multiproduct_generation.cc
+++ b/sxt/multiexp/random/random_multiproduct_generation.cc
@@ -1,0 +1,79 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/random/random_multiproduct_generation.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "sxt/base/error/panic.h"
+#include "sxt/multiexp/index/index_table.h"
+#include "sxt/multiexp/index/reindex.h"
+#include "sxt/multiexp/random/random_multiproduct_descriptor.h"
+
+namespace sxt::mtxrn {
+//--------------------------------------------------------------------------------------------------
+// generate_random_multiproduct
+//--------------------------------------------------------------------------------------------------
+void generate_random_multiproduct(mtxi::index_table& products, size_t& num_inputs,
+                                  size_t& num_entries, std::mt19937& rng,
+                                  const random_multiproduct_descriptor& descriptor) noexcept {
+  if (descriptor.max_sequence_length > descriptor.max_num_inputs) {
+    baser::panic("max_sequence_length must be less than or equal to max_num_inputs");
+  }
+
+  // determine the product table dimensions
+  std::uniform_int_distribution<size_t> num_sequences_dist{descriptor.min_num_sequences,
+                                                           descriptor.max_num_sequences};
+  auto num_sequences = num_sequences_dist(rng);
+
+  std::vector<size_t> sequence_lengths(num_sequences);
+  std::uniform_int_distribution<size_t> sequence_length_dist{
+      descriptor.min_sequence_length,
+      descriptor.max_sequence_length,
+  };
+  num_entries = 0;
+  for (size_t sequence_index = 0; sequence_index < num_sequences; ++sequence_index) {
+    auto n = sequence_length_dist(rng);
+    sequence_lengths[sequence_index] = n;
+    num_entries += n;
+  }
+  products.reshape(num_sequences, num_entries);
+
+  // fill the product table
+  auto entry_data = products.entry_data();
+  for (size_t row_index = 0; row_index < products.num_rows(); ++row_index) {
+    auto n = sequence_lengths[row_index];
+    auto& row = products.header()[row_index];
+    row = {entry_data, n};
+    uint64_t lower_bound = 0;
+    for (size_t index = 0; index < n; ++index) {
+      std::uniform_int_distribution<uint64_t> entry_dist{lower_bound,
+                                                         descriptor.max_num_inputs - n + index};
+      auto entry = entry_dist(rng);
+      *entry_data++ = entry;
+      lower_bound = entry + 1;
+    }
+  }
+
+  // reindex the product table
+  std::vector<uint64_t> values_data(num_entries);
+  basct::span<uint64_t> values = values_data;
+  mtxi::reindex_rows(products.header(), values);
+  num_inputs = values.size();
+}
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/random/random_multiproduct_generation.h
+++ b/sxt/multiexp/random/random_multiproduct_generation.h
@@ -1,0 +1,39 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include <memory_resource>
+#include <random>
+
+#include "sxt/base/container/span.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::mtxi {
+class index_table;
+}
+
+namespace sxt::mtxrn {
+struct random_multiproduct_descriptor;
+
+//--------------------------------------------------------------------------------------------------
+// generate_random_multiproduct
+//--------------------------------------------------------------------------------------------------
+void generate_random_multiproduct(mtxi::index_table& products, size_t& num_inputs,
+                                  size_t& num_entries, std::mt19937& rng,
+                                  const random_multiproduct_descriptor& descriptor) noexcept;
+} // namespace sxt::mtxrn

--- a/sxt/multiexp/test/BUILD
+++ b/sxt/multiexp/test/BUILD
@@ -1,0 +1,71 @@
+load(
+    "//bazel:sxt_component.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "add_ints",
+    impl_deps = [
+        "//sxt/base/error:panic",
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "curve21_arithmetic",
+    impl_deps = [
+        "//sxt/base/container:stack_array",
+        "//sxt/base/num:constexpr_switch",
+        "//sxt/base/num:ceil_log2",
+        "//sxt/base/type:int",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/curve21/operation:add",
+        "//sxt/curve21/operation:neg",
+        "//sxt/curve21/operation:scalar_multiply",
+        "//sxt/curve21/property:curve",
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "compute_uint64_muladd",
+    impl_deps = [
+        "//sxt/multiexp/base:exponent_sequence",
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiexponentiation",
+    impl_deps = [
+        ":curve21_arithmetic",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/curve21/operation:overload",
+        "//sxt/ristretto/type:literal",
+        "//sxt/ristretto/operation:compression",
+        "//sxt/multiexp/base:exponent_sequence",
+        "//sxt/multiexp/random:random_multiproduct_descriptor",
+        "//sxt/multiexp/random:random_multiproduct_generation",
+        "//sxt/multiexp/random:random_multiexponentiation_descriptor",
+        "//sxt/multiexp/random:random_multiexponentiation_generation",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/base:exponent_sequence_utility",
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/functional:function_ref",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)

--- a/sxt/multiexp/test/add_ints.cc
+++ b/sxt/multiexp/test/add_ints.cc
@@ -1,0 +1,44 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/test/add_ints.h"
+
+#include <cstdlib>
+#include <iostream>
+
+#include "sxt/base/error/panic.h"
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// add_ints
+//--------------------------------------------------------------------------------------------------
+void add_ints(basct::span<uint64_t> result, basct::cspan<basct::cspan<uint64_t>> terms,
+              basct::cspan<uint64_t> inputs) noexcept {
+  if (result.size() != terms.size()) {
+    baser::panic("result.size() != terms.size()");
+  }
+  for (size_t result_index = 0; result_index < result.size(); ++result_index) {
+    auto& res_i = result[result_index];
+    res_i = 0;
+    for (auto term_index : terms[result_index]) {
+      if (term_index >= inputs.size()) {
+        baser::panic("term_index >= inputs.size()");
+      }
+      res_i += inputs[term_index];
+    }
+  }
+}
+} // namespace sxt::mtxtst

--- a/sxt/multiexp/test/add_ints.h
+++ b/sxt/multiexp/test/add_ints.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// add_ints
+//--------------------------------------------------------------------------------------------------
+void add_ints(basct::span<uint64_t> result, basct::cspan<basct::cspan<uint64_t>> terms,
+              basct::cspan<uint64_t> inputs) noexcept;
+} // namespace sxt::mtxtst

--- a/sxt/multiexp/test/compute_uint64_muladd.cc
+++ b/sxt/multiexp/test/compute_uint64_muladd.cc
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/test/compute_uint64_muladd.h"
+
+#include "sxt/multiexp/base/exponent_sequence.h"
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// compute_uint64_muladd
+//--------------------------------------------------------------------------------------------------
+void compute_uint64_muladd(basct::span<uint64_t> result, basct::span<uint64_t> generators,
+                           basct::span<mtxb::exponent_sequence> sequences) noexcept {
+
+  // compute the expected result
+  for (size_t seq = 0; seq < result.size(); ++seq) {
+    result[seq] = 0;
+
+    uint8_t element_nbytes = sequences[seq].element_nbytes;
+
+    // sum all the elements in the current sequence together
+    for (size_t gen_i = 0; gen_i < sequences[seq].n; ++gen_i) {
+      uint64_t pow256 = 1;
+      uint64_t curr_exponent = 0;
+
+      // reconstructs the gen_i-th data element out of its element_nbytes values
+      for (size_t j = 0; j < element_nbytes; ++j) {
+        curr_exponent += sequences[seq].data[gen_i * element_nbytes + j] * pow256;
+        pow256 *= 256;
+      }
+
+      result[seq] += generators[gen_i] * curr_exponent;
+    }
+  }
+}
+} // namespace sxt::mtxtst

--- a/sxt/multiexp/test/compute_uint64_muladd.h
+++ b/sxt/multiexp/test/compute_uint64_muladd.h
@@ -1,0 +1,33 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// compute_uint64_muladd
+//--------------------------------------------------------------------------------------------------
+void compute_uint64_muladd(basct::span<uint64_t> result, basct::span<uint64_t> generators,
+                           basct::span<mtxb::exponent_sequence> sequences) noexcept;
+} // namespace sxt::mtxtst

--- a/sxt/multiexp/test/curve21_arithmetic.cc
+++ b/sxt/multiexp/test/curve21_arithmetic.cc
@@ -1,0 +1,111 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/test/curve21_arithmetic.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+
+#include "sxt/base/container/stack_array.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/num/ceil_log2.h"
+#include "sxt/base/num/constexpr_switch.h"
+#include "sxt/base/type/int.h"
+#include "sxt/curve21/operation/add.h"
+#include "sxt/curve21/operation/neg.h"
+#include "sxt/curve21/operation/scalar_multiply.h"
+#include "sxt/curve21/property/curve.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// read_exponent
+//--------------------------------------------------------------------------------------------------
+static void read_exponent(c21t::element_p3& e, basct::span<uint8_t>& exponent,
+                          const mtxb::exponent_sequence& sequence, size_t index) noexcept {
+  uint8_t element_nbytes = sequence.element_nbytes;
+  exponent = {exponent.data(), element_nbytes};
+  std::copy_n(sequence.data + index * element_nbytes, element_nbytes, exponent.data());
+  if (!static_cast<bool>(sequence.is_signed)) {
+    return;
+  }
+  basn::constexpr_switch<4>(
+      basn::ceil_log2(element_nbytes),
+      [&]<unsigned NumBytesLg2>(std::integral_constant<unsigned, NumBytesLg2>) noexcept {
+        static constexpr auto NumBytes = 1ull << NumBytesLg2;
+        bast::sized_int_t<NumBytes * 8> x{};
+        std::copy_n(exponent.begin(), element_nbytes, reinterpret_cast<uint8_t*>(&x));
+        auto abs_x = std::abs(x);
+        if (x == abs_x) {
+          return;
+        }
+        c21o::neg(e, e);
+        std::copy_n(reinterpret_cast<uint8_t*>(&abs_x), element_nbytes, exponent.begin());
+      });
+}
+
+//--------------------------------------------------------------------------------------------------
+// sum_curve21_elements
+//--------------------------------------------------------------------------------------------------
+void sum_curve21_elements(basct::span<c21t::element_p3> result,
+                          basct::cspan<basct::cspan<uint64_t>> terms,
+                          basct::cspan<c21t::element_p3> inputs) noexcept {
+  SXT_RELEASE_ASSERT(result.size() == terms.size());
+  for (size_t result_index = 0; result_index < result.size(); ++result_index) {
+    auto& res_i = result[result_index];
+    res_i = c21t::element_p3::identity();
+    for (auto term_index : terms[result_index]) {
+      SXT_RELEASE_ASSERT(term_index < inputs.size());
+      c21o::add(res_i, res_i, inputs[term_index]);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// mul_sum_curve21_elements
+//--------------------------------------------------------------------------------------------------
+void mul_sum_curve21_elements(basct::span<c21t::element_p3> result,
+                              basct::cspan<c21t::element_p3> generators,
+                              basct::cspan<mtxb::exponent_sequence> sequences) noexcept {
+  SXT_RELEASE_ASSERT(result.size() == sequences.size());
+  SXT_STACK_ARRAY(exponent, 32, uint8_t);
+  for (size_t output_index = 0; output_index < result.size(); ++output_index) {
+    c21t::element_p3 output = c21t::element_p3::identity();
+    auto sequence = sequences[output_index];
+    SXT_RELEASE_ASSERT(sequence.n <= generators.size());
+    for (size_t generator_index = 0; generator_index < sequence.n; ++generator_index) {
+      auto e = generators[generator_index];
+      read_exponent(e, exponent, sequence, generator_index);
+      if (exponent.size() == 32) {
+        // split multiplication into multiple steps to avoid a scalar25 reduction -- this allows us
+        // to compare curve21 elements directly
+        c21o::scalar_multiply(e, exponent.subspan(1), e);
+        c21o::scalar_multiply(e, 1ul << 8, e);
+        c21o::add(output, output, e);
+        e = generators[generator_index];
+        c21o::scalar_multiply(e, exponent.subspan(0, 1), e);
+      } else {
+        c21o::scalar_multiply(e, exponent, e);
+      }
+      SXT_RELEASE_ASSERT(c21p::is_on_curve(e));
+      c21o::add(output, output, e);
+    }
+    result[output_index] = output;
+  }
+}
+} // namespace sxt::mtxtst

--- a/sxt/multiexp/test/curve21_arithmetic.h
+++ b/sxt/multiexp/test/curve21_arithmetic.h
@@ -1,0 +1,44 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::c21t {
+struct element_p3;
+}
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// sum_curve21_elements
+//--------------------------------------------------------------------------------------------------
+void sum_curve21_elements(basct::span<c21t::element_p3> result,
+                          basct::cspan<basct::cspan<uint64_t>> terms,
+                          basct::cspan<c21t::element_p3> inputs) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// mul_sum_curve21_elements
+//--------------------------------------------------------------------------------------------------
+void mul_sum_curve21_elements(basct::span<c21t::element_p3> result,
+                              basct::cspan<c21t::element_p3> generators,
+                              basct::cspan<mtxb::exponent_sequence> sequences) noexcept;
+} // namespace sxt::mtxtst

--- a/sxt/multiexp/test/multiexponentiation.cc
+++ b/sxt/multiexp/test/multiexponentiation.cc
@@ -1,0 +1,433 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/test/multiexponentiation.h"
+
+#include <cstdint>
+#include <limits>
+#include <memory_resource>
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve21/operation/overload.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/multiexp/base/exponent_sequence.h"
+#include "sxt/multiexp/base/exponent_sequence_utility.h"
+#include "sxt/multiexp/random/random_multiexponentiation_descriptor.h"
+#include "sxt/multiexp/random/random_multiexponentiation_generation.h"
+#include "sxt/multiexp/test/curve21_arithmetic.h"
+#include "sxt/ristretto/operation/compression.h"
+#include "sxt/ristretto/type/literal.h"
+
+using sxt::rstt::operator""_rs;
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// exercise_multiexponentiation_fn
+//--------------------------------------------------------------------------------------------------
+void exercise_multiexponentiation_fn(std::mt19937& rng, multiexponentiation_fn f) noexcept {
+  // bespoke test cases
+  SECTION("we handle the empty case") {
+    std::vector<mtxb::exponent_sequence> sequences;
+    auto res = f({}, {});
+    REQUIRE(res.empty());
+  }
+
+  SECTION("we handle a sequence with no exponents") {
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = 0, .data = nullptr}};
+    auto res = f({}, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        c21t::element_p3::identity(),
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle an exponent of zero") {
+    std::vector<uint32_t> exponents = {0};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        c21t::element_p3::identity(),
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle an exponent of one") {
+    std::vector<uint32_t> exponents = {1};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+    };
+    auto res = f(generators, sequences);
+    REQUIRE(res == generators);
+  }
+
+  SECTION("we handle an exponent of negative one") {
+    std::vector<int32_t> exponents = {-1};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        -generators[0],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle an exponent of two") {
+    std::vector<uint32_t> exponents = {2};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        generators[0] + generators[0],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle an exponent of three") {
+    std::vector<uint32_t> exponents = {3};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        generators[0] + generators[0] + generators[0],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we can handle a large exponent") {
+    std::vector<uint64_t> exponents = {std::numeric_limits<uint64_t>::max()};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        exponents[0] * generators[0],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle sequences with more than a single element") {
+    std::vector<uint16_t> exponents = {3, 2};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+        0x456_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        3 * generators[0] + 2 * generators[1],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle sequences with a mix of positive and negative elements") {
+    std::vector<int> exponents = {3, -2, 4, -1};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+        0x456_rs,
+        0x789_rs,
+        0x101_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        3 * generators[0] - 2 * generators[1] + 4 * generators[2] - generators[3],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle multiple sequences of length zero") {
+    std::vector<mtxb::exponent_sequence> sequences = {
+        {.element_nbytes = 1, .n = 0, .data = nullptr},
+        {.element_nbytes = 1, .n = 0, .data = nullptr}};
+    auto res = f({}, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        c21t::element_p3::identity(),
+        c21t::element_p3::identity(),
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle multiple sequences with a single exponent") {
+    std::vector<uint8_t> exponents1 = {1};
+    std::vector<uint16_t> exponents2 = {3};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents1),
+        mtxb::to_exponent_sequence(exponents2),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        generators[0],
+        3 * generators[0],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle multiple sequences with multiple exponents") {
+    std::vector<uint8_t> exponents1 = {1, 10, 3};
+    std::vector<uint16_t> exponents2 = {2, 6, 4};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents1),
+        mtxb::to_exponent_sequence(exponents2),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+        0x456_rs,
+        0x789_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        generators[0] + 10 * generators[1] + 3 * generators[2],
+        2 * generators[0] + 6 * generators[1] + 4 * generators[2],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle multiple sequences with multiple exponents where one is all zero") {
+    std::vector<uint8_t> exponents1 = {0, 0, 0};
+    std::vector<uint16_t> exponents2 = {2, 6, 4};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents1),
+        mtxb::to_exponent_sequence(exponents2),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+        0x456_rs,
+        0x789_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        c21t::element_p3::identity(),
+        2 * generators[0] + 6 * generators[1] + 4 * generators[2],
+    };
+    REQUIRE(res == expected);
+  }
+
+  SECTION("we handle multiple sequences  of varying length") {
+    std::vector<uint8_t> exponents1 = {10};
+    std::vector<uint16_t> exponents2 = {2, 6, 4};
+    std::vector<mtxb::exponent_sequence> sequences = {
+        mtxb::to_exponent_sequence(exponents1),
+        mtxb::to_exponent_sequence(exponents2),
+    };
+    memmg::managed_array<c21t::element_p3> generators = {
+        0x123_rs,
+        0x456_rs,
+        0x789_rs,
+    };
+    auto res = f(generators, sequences);
+    memmg::managed_array<c21t::element_p3> expected = {
+        10 * generators[0],
+        2 * generators[0] + 6 * generators[1] + 4 * generators[2],
+    };
+    REQUIRE(res == expected);
+  }
+
+  // random test cases
+  std::pmr::monotonic_buffer_resource resource;
+  basct::span<mtxb::exponent_sequence> sequences;
+  basct::span<c21t::element_p3> generators;
+
+  SECTION("we handle random sequences of varying length") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 1,
+        .min_sequence_length = 0,
+        .max_sequence_length = 100,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 1,
+    };
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+
+  SECTION("we handle multiple products and random sequences of length 1") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .min_sequence_length = 1,
+        .max_sequence_length = 1,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 1,
+    };
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+
+  SECTION("we handle multiple products and random sequences of varying length") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .min_sequence_length = 1,
+        .max_sequence_length = 100,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 1,
+    };
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+
+  SECTION("we handle random sequences of length 1 and varying num_bytes") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 1,
+        .min_sequence_length = 1,
+        .max_sequence_length = 1,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 32,
+    };
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+
+  SECTION("we handle random sequences of varying length and varying num_bytes") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 1,
+        .min_sequence_length = 1,
+        .max_sequence_length = 100,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 32,
+    };
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+
+  SECTION("we handle multiple products of random sequences of varying length and varying "
+          "num_bytes") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .min_sequence_length = 1,
+        .max_sequence_length = 100,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 32,
+    };
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+
+  SECTION("we handle multiple products of random sequences of varying signs") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .min_sequence_length = 1,
+        .max_sequence_length = 100,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 1,
+    };
+    size_t index = 0;
+    for (int i = 0; i < 10; ++i) {
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      for (auto& seq : sequences) {
+        seq.is_signed = index++ % 2;
+      }
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+
+  SECTION(
+      "we handle multiple products of random sequences of varying signs and varying num_bytes") {
+    mtxrn::random_multiexponentiation_descriptor descriptor{
+        .min_num_sequences = 1,
+        .max_num_sequences = 10,
+        .min_sequence_length = 1,
+        .max_sequence_length = 100,
+        .min_exponent_num_bytes = 1,
+        .max_exponent_num_bytes = 1,
+    };
+    size_t index = 0;
+    for (int i = 0; i < 10; ++i) {
+      auto num_bytes = 1ull << (i % 4);
+      descriptor.min_exponent_num_bytes = num_bytes;
+      descriptor.max_exponent_num_bytes = num_bytes;
+      mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);
+      for (auto& seq : sequences) {
+        seq.is_signed = index++ % 2;
+      }
+      auto res = f(generators, sequences);
+      memmg::managed_array<c21t::element_p3> expected(sequences.size());
+      mtxtst::mul_sum_curve21_elements(expected, generators, sequences);
+      REQUIRE(res == expected);
+    }
+  }
+}
+} // namespace sxt::mtxtst

--- a/sxt/multiexp/test/multiexponentiation.h
+++ b/sxt/multiexp/test/multiexponentiation.h
@@ -1,0 +1,43 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <random>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/functional/function_ref.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::c21t {
+struct element_p3;
+}
+namespace sxt::mtxb {
+struct exponent_sequence;
+}
+
+namespace sxt::mtxtst {
+//--------------------------------------------------------------------------------------------------
+// multiexponentiation_fn
+//--------------------------------------------------------------------------------------------------
+using multiexponentiation_fn = basf::function_ref<memmg::managed_array<c21t::element_p3>(
+    basct::cspan<c21t::element_p3>, basct::cspan<mtxb::exponent_sequence> exponents)>;
+
+//--------------------------------------------------------------------------------------------------
+// exercise_multiexponentiation_fn
+//--------------------------------------------------------------------------------------------------
+void exercise_multiexponentiation_fn(std::mt19937& rng, multiexponentiation_fn f) noexcept;
+} // namespace sxt::mtxtst


### PR DESCRIPTION
Current error in this branch

```
ERROR: /src/sxt/multiexp/multiproduct_gpu/BUILD:55:17: Compiling sxt/multiexp/multiproduct_gpu/kernel.t.cc failed: (Exit 1): clang failed: error executing command (from target //sxt/multiexp/multiproduct_gpu:kernel-test-lib) /usr/bin/clang -x cu '--cuda-gpu-arch=sm_70' '--cuda-gpu-arch=sm_70' -fcuda-rdc '--cuda-path=/usr/local/cuda' ... (remaining 42 arguments skipped)
clang: warning: CUDA version 12.1 is only partially supported [-Wunknown-cuda-version]
In file included from sxt/multiexp/multiproduct_gpu/kernel.t.cc:17:
In file included from ./sxt/multiexp/multiproduct_gpu/kernel.h:25:
./sxt/execution/kernel/launch.h:32:1: warning: unknown pragma ignored [-Wunknown-pragmas]
   32 | CUDA_DISABLE_HOSTDEV_WARNING
      | ^
./sxt/base/macro/cuda_warning.h:20:38: note: expanded from macro 'CUDA_DISABLE_HOSTDEV_WARNING'
   20 | #define CUDA_DISABLE_HOSTDEV_WARNING _Pragma("nv_exec_check_disable")
      |                                      ^
<scratch space>:151:2: note: expanded from here
  151 |  nv_exec_check_disable
      |  ^
1 warning generated when compiling for sm_70.
ptxas /tmp/kernel-sm_70-b82622.s, line 300; fatal   : Variable used as initial value not in .global or .const state space
ptxas fatal   : Ptx assembly aborted due to errors
clang: error: ptxas command failed with exit code 255 (use -v to see invocation)
Ubuntu clang version 18.0.0 (++20230906042404+2a7b8ab07c26-1~exp1~20230906042538.1168)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
clang: note: diagnostic msg: 
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /tmp/kernel-74b7c4.cu
clang: note: diagnostic msg: /tmp/kernel-sm_70-57cfaf.cu
clang: note: diagnostic msg: /tmp/kernel-74b7c4.sh
clang: note: diagnostic msg: 

********************
INFO: Elapsed time: 41.210s, Critical Path: 5.04s
INFO: 3135 processes: 1415 internal, 1720 local.
FAILED: Build did NOT complete successfully
```